### PR TITLE
add tools for udhr samples and ohchr attributions

### DIFF
--- a/nototools/extract_ohchr_attributions.py
+++ b/nototools/extract_ohchr_attributions.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract attribution data from the ohchr UDHR site."""
+
+# This tool generates a .tsv file of attribution data based on information at the ohchr
+# site, but first you have to manually extract that data from the html on the site, as
+# there's no convenient way to get it.  This block of comments describes the process.
+#
+# The idea is to find out which data on the ohchr site is 'official United Nations' data
+# and which is not.  The data itself doesn't say, so we need to look at the attributions
+# listed on the ohchr.org site.
+#
+# Note that the data we actually use is not directly from ohchr.org, but from
+# www.unicode.org/udhr.  That site has cleaned up the data a little and converted it to
+# xml format.  We are assuming that any data with a matching language code shares the
+# original attribution, but we could be wrong.  The unicode.org site does not have the
+# attribution data in any kind of organized form.  Instead, they put a comment at the top
+# of each document giving copyright to "The Office of the High Commisioner for Human
+# Rights."
+#
+# Unfortunately, the data at www.ohchr.org is not readily available.  At
+# http://www.ohchr.org/EN/UDHR/Pages/SearchByLang.aspx you can page through the data using
+# the dropdown under 'Search by Translation', but there's no visible url for a single page
+# or for the data as a whole.
+#
+# If you try to view each page and then 'save as...', chrome fetches the url for the page
+# it is showing, which returns the first (default) page no matter what data you are
+# actually viewing.  'View as source' works, but it provides a formatted page, and if you
+# choose 'save as...' from there, you get the source for that formatted page, not the raw
+# source.  The only way to get the source is to select and copy it from the source view
+# into another document.
+#
+# At this point it makes more sense to just grab the portion of the data we can use
+# instead of the whole file.  So the process is to use the dropdown to show one of the
+# pages of translations and then choose view source for it.  Copy the contents of the
+# <table> tag that lists the languages and sources into a stub html file.  Repeat this for
+# each of the six dropdown pages.  The stub contains a single table element with the id
+# 'ohchr_alldata', after this the table contains the data from all six ohchr pages.
+#
+# This data is still odd, in particular it nests <tr> and <td> tags.  Fortunately
+# HTMLParser doesn't care, and we don't need to care.  The three pieces of data are the
+# 'ohchr code', the 'language name', and the 'source'.  The ohchr code is how they link to
+# the page for the translation, mostly it is a three-letter language code but sometimes it
+# is just whatever their server uses.  The 'language name' is more or less an English
+# translation of the language, sometimes with notes on script or region or the native name
+# of the language, and the attribution is a string.  The data is structured so that the
+# ohchr code is part of an anchor tag that wraps the language string, and the source is
+# part of a span in the following td.  There are no other anchor tags or spans in the
+# data, so we can just look for these.  Separating each set is a close tr tag, so we can
+# emit the data then.
+#
+# The output is a list of records with tab-separated fields: ohchr_code, lang_name, and
+# source_name.  The udhr index at unicode.org references the 'ohchr' code, so this is how
+# we tie the attributions to the data from unicode.org.
+
+
+import argparse
+import HTMLParser as html
+import re
+
+class ParseOhchr(html.HTMLParser):
+  def __init__(self, trace=False):
+    html.HTMLParser.__init__(self)
+    self.trace = trace
+    self.result_list = []
+    self.restart()
+
+  def restart(self):
+    self.margin = ''
+    self.state = 'before_table'
+    self.tag_stack = []
+    self.collect_lang = False
+    self.collect_source = False
+    self.ohchr_code = ''
+    self.lang_name = ''
+    self.source_name = ''
+
+  def results(self):
+    return self.result_list
+
+  def indent(self):
+    self.margin += '  '
+
+  def outdent(self):
+    if not self.margin:
+      print '*** cannot outdent ***'
+    else:
+      self.margin = self.margin[:-2]
+
+  def get_attr(self, attr_list, attr_id):
+    for t in attr_list:
+      if t[0] == attr_id:
+        return t[1]
+    return None
+
+  def handle_starttag(self, tag, attrs):
+    if tag not in ['link', 'meta', 'area', 'img', 'br']:
+      if self.trace:
+        print self.margin + tag + '>'
+      self.tag_stack.append((tag, self.getpos()))
+      self.indent()
+    elif self.trace:
+      print self.margin + tag
+
+    if self.state == 'before_table' and tag == 'table':
+      table_id = self.get_attr(attrs, 'id')
+      if table_id == 'ohchr_alldata':
+        self.state = 'in_table'
+    elif self.state == 'in_table':
+      if tag == 'tr':
+        self.ohchr_code = ''
+        self.lang_name = ''
+        self.source_name = ''
+      elif tag == 'a':
+        a_id = self.get_attr(attrs, 'id')
+        if a_id and a_id.endswith('_hpLangTitleID'):
+          ohchr_code = self.get_attr(attrs, 'href')
+          ix = ohchr_code.rfind('=')
+          self.ohchr_code = ohchr_code[ix+1:]
+          self.collect_lang = True
+      elif tag == 'span':
+        span_id = self.get_attr(attrs, 'id')
+        if span_id and span_id.endswith('_lblSourceID'):
+          self.collect_source = True
+      elif tag == 'td':
+        self.collect_lang = False
+        self.collect_source = False
+
+  def handle_endtag(self, tag):
+    while self.tag_stack:
+      prev_tag, prev_pos = self.tag_stack.pop()
+      self.outdent()
+      if tag != prev_tag:
+        if self.trace:
+          print 'no close tag for %s at %s' % (prev_tag, prev_pos)
+      else:
+        break
+    if self.trace:
+      print self.margin + '<'
+    if self.state == 'in_table':
+      if tag == 'table':
+        self.state = 'after_table'
+      elif tag == 'tr':
+        if self.ohchr_code:
+          self.lang_name = re.sub(r'\s+', ' ', self.lang_name).strip()
+          self.source_name = re.sub(r'\s+', ' ', self.source_name).strip()
+          if not self.source_name:
+            self.source_name = '(no attribution)'
+          self.result_list.append((self.ohchr_code, self.lang_name, self.source_name))
+          self.ohchr_code = ''
+          self.lang_name = ''
+          self.source_name = ''
+
+  def handle_data(self, data):
+    if self.collect_lang:
+      self.lang_name += data
+    elif self.collect_source:
+      self.source_name += data
+    pass
+
+def get_ohchr_status(ohchr_code, lang, attrib):
+  if ohchr_code in ['eng', 'frn', 'spn', 'rus', 'chn', 'arz']:
+    return 'original'
+  if (attrib.find('United Nations') != -1 or
+      attrib.find('High Commissioner for Human Rights') != -1):
+    return 'UN'
+  return 'other'
+
+def parse_ohchr_html_file(htmlfile):
+  parser = ParseOhchr(False)
+  with open(htmlfile) as f:
+    parser.feed(f.read())
+
+  for ohchr_code, lang, attrib in parser.results():
+    s = get_ohchr_status(ohchr_code, lang, attrib)
+    print '\t'.join([ohchr_code, s, lang, attrib])
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--file', help='input ohchr html file', metavar='file', required=True,
+                      dest='htmlfile')
+  args = parser.parse_args()
+
+  parse_ohchr_html_file(args.htmlfile)
+
+if __name__ == '__main__':
+    main()

--- a/nototools/tool_utils.py
+++ b/nototools/tool_utils.py
@@ -17,10 +17,13 @@
 import contextlib
 import datetime
 import os
+import re
 import shutil
 import subprocess
 import time
 import zipfile
+
+from nototools import notoconfig
 
 @contextlib.contextmanager
 def temp_chdir(path):
@@ -33,6 +36,23 @@ def temp_chdir(path):
     yield
   finally:
     os.chdir(saved_dir)
+
+
+noto_re = re.compile(r'\[(tools|fonts|emoji|cjk)\]/(.*)')
+def resolve_path(path):
+  """Resolve a path that might use noto path shorthand."""
+
+  if not path or path == '-':
+    return None
+  m = noto_re.match(path)
+  if m:
+    base, rest = m.groups()
+    base = notoconfig.values.get('noto_' + base)
+    path = os.path.join(base, rest)
+  path = os.path.expanduser(path)
+  path = os.path.abspath(path)
+  path = os.path.realpath(path)
+  return path
 
 
 def check_dir_exists(dirpath):

--- a/nototools/tool_utils.py
+++ b/nototools/tool_utils.py
@@ -47,7 +47,10 @@ def resolve_path(path):
   m = noto_re.match(path)
   if m:
     base, rest = m.groups()
-    base = notoconfig.values.get('noto_' + base)
+    key = 'noto_' + base
+    if not key in notoconfig.values:
+      raise ValueError('notoconfig has no entry for %s' % key)
+    base = notoconfig.values.get(key)
     path = os.path.join(base, rest)
   path = os.path.expanduser(path)
   path = os.path.abspath(path)

--- a/nototools/update_cldr.py
+++ b/nototools/update_cldr.py
@@ -90,9 +90,8 @@ def update_cldr(noto_repo, cldr_repo, update=False, cldr_tag=''):
     dst = os.path.join(noto_cldr, f)
     shutil.copy(src, dst)
 
-  # git can now add everything, even removed files
-  with tool_utils.temp_chdir(noto_cldr):
-    subprocess.check_call(['git', 'add', '--', '.'])
+  # stage changes in cldr dir
+  tool_utils.git_add_all(noto_cldr)
 
   # print commit message
   tag_string = (' tag %s' % cldr_tag) if cldr_tag else ''
@@ -114,11 +113,11 @@ def main():
   args = parser.parse_args()
 
   if not args.cldr or not args.noto:
-    print "need both cldr and noto repository information"
+    print "Missing either or both of cldr and noto locations."
     return
 
   if args.branch:
-    cur_branch = git_get_branch(args.noto)
+    cur_branch = tool_utils.git_get_branch(args.noto)
     if cur_branch != args.branch:
       print "Expected branch '%s' but %s is in branch '%s'." % (args.branch, args.noto, cur_branch)
       return

--- a/nototools/update_udhr_samples.py
+++ b/nototools/update_udhr_samples.py
@@ -1,0 +1,581 @@
+#!/usr/bin/python
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Grab Universal Declaration of Human Rights data from unicode.org/udhr,
+extract the text of Article 1 where it seems ok, and generate text files
+using the bcp47 name (including script) for the language of that sample."""
+
+import argparse
+import codecs
+import collections
+import datetime
+import difflib
+import generate_website_data
+import os
+import re
+import shutil
+import unicode_data
+import urllib
+import xml.etree.ElementTree as ET
+import zipfile
+
+import notoconfig
+import tool_utils
+
+DIR_URL = 'http://unicode.org/udhr/d'
+UDHR_XML_ZIP_NAME = 'udhr_xml.zip'
+UDHR_XML_ZIP_URL = 'http://unicode.org/udhr/assemblies/' + UDHR_XML_ZIP_NAME
+
+def fetch_udhr(fetch_dir):
+  """Fetch UDHR xml bundle from unicode.org to fetch_dir."""
+  fetch_dir = tool_utils.ensure_dir_exists(fetch_dir)
+  dstfile = os.path.join(fetch_dir, UDHR_XML_ZIP_NAME)
+  result = urllib.urlretrieve(UDHR_XML_ZIP_URL, dstfile)
+  print 'Fetched: ' + result[0]
+
+
+def update_udhr(udhr_dir, fetch_dir, in_repo):
+  """Delete udhr_dir and rebuild with files extracted from udhr_xml.zip
+  in fetch_dir. Stage if udhr_dir is in the repo."""
+
+  zippath = os.path.join(fetch_dir, UDHR_XML_ZIP_NAME)
+  tool_utils.check_file_exists(zippath)
+
+  if in_repo and os.path.isdir(udhr_dir) and not tool_utils.git_is_clean(udhr_dir):
+    raise ValueError('Please clean %s.' % udhr_dir)
+
+  if os.path.isdir(udhr_dir):
+    shutil.rmtree(udhr_dir)
+  os.makedirs(udhr_dir)
+  tool_utils.zip_extract_with_timestamp(zippath, udhr_dir)
+
+  if in_repo:
+    tool_utils.git_add_all(udhr_dir)
+
+  date = datetime.datetime.now().strftime('%Y-%m-%d')
+  dst = 'in %s ' % udhr_dir if not in_repo else ''
+  print 'Update UDHR files %sfrom %s as of %s.' % (dst, fetch_dir, date)
+
+
+def parse_index(src_dir):
+  """Parse the index.xml file in src_dir and return a map from bcp to a set of
+  file codes.
+
+  Skip files at stages 1 (missing) or 2 (not started). Stage 3 files have
+  article 1, which is what we want.  Stage 4 and 5 are ok, the vast majority are
+  unreviewed (4).
+
+  In some cases more than one file is mapped to the same bcp47 code, this gets
+  dealt with in fix_index."""
+
+  tree = ET.parse(os.path.join(src_dir, 'index.xml'))
+  bcp_to_codes = collections.defaultdict(set)
+  code_to_ohchr = {}
+
+  for e in tree.getroot().iter('udhr'):
+    s = int(e.attrib.get('stage'))
+    if s < 3:
+      continue
+
+    l = e.attrib.get('l')
+    v = e.attrib.get('v')
+    code = l + ('_' + v if v else '')
+
+    bcp = e.attrib.get('bcp47')
+    if not bcp:
+      # don't know what to do with this, maybe we could supply a mapping.
+      print 'no bcp for %s' % code
+      continue
+
+    ohchr = e.attrib.get('ohchr')
+
+    bcp_to_codes[bcp].add(code)
+
+    # we use the ohchr code to identify an attribution
+    if ohchr:
+      code_to_ohchr[code] = ohchr
+
+  return bcp_to_codes, code_to_ohchr
+
+
+# These handle cases in which (as of March 25, 2015) the unicode udhr data
+# has multiple files with the same bcp47 code.
+# In some cases, we pick just the one code to use, more or less arbitrarily.
+# In other cases, we generate different bcp47 codes for the different files,
+# by adding a region or variant tag to the code.
+BCP_FIXES = {
+  'acu': 'acu', # drop acu_1
+  'ak': [('ak-asante', 'aka_asante'), ('ak-fante', 'aka_fante')],
+  'cjk': [('cjk', 'cjk'), ('cjk-AO', 'cjk_AO')],
+  'fa': 'pes_2', #drop pes_1
+  'ht': [('ht-popular', 'hat_popular'), ('ht-kreyol', 'hat_kreyol')],
+  'kg': [('kg', 'kng'), ('kg-AO', 'kng_AO')],
+  'la': 'lat', # drop lat_1
+  'ln': 'lin_tones', # drop lin
+  'ny': [('ny-chinyanj', 'nya_chinyanja'), ('ny-chechewa', 'nya_chechewa')], # max 8 chars
+  'oc': 'lnc', # drop auv
+  'ro': 'ron_2006', # drop 1993, 1953
+  'rom': 'rmn' # drop rmn_1
+  }
+
+def fix_index(bcp_to_codes):
+  """Take a mapping from bcp to a set of file codes, and
+  select the mappings we want using a whitelist.  We return
+  a mapping from one bcp47 code to one file code."""
+  result = {}
+  for k, v in bcp_to_codes.iteritems():
+    if len(v) == 1:
+      result[k] = next(iter(v))
+    elif not k in BCP_FIXES:
+      print 'No fix for %s (%s)' % (k, v)
+    else:
+      fix = BCP_FIXES[k]
+      if isinstance(fix, basestring):
+        print 'for %s (%s) select %s' % (k, ', '.join(v), fix)
+        result[k] = fix
+      else:
+        fixes = []
+        for newk, newv in fix:
+          fixes.append('%s=%s' % (newk, newv))
+          result[newk] = newv
+        print 'for %s (%s) select %s' % (k, ', '.join(v), ', '.join(fixes))
+
+  return result
+
+
+# The likely script data doesn't always match the samples, so we override it here.
+# Probably should always get the samples first and apply the script later, but for
+# now we just check after the fact.
+CODE_TO_BCP = {
+  'evn': 'evn-Cyrl',
+  'ojb': 'oj-Cans'}
+
+def add_likely_scripts(bcp_to_code):
+  """Add script subtags where they are not present in the bcp code."""
+  result= {}
+  for bcp, code in bcp_to_code.iteritems():
+    if code in CODE_TO_BCP:
+      new_bcp = CODE_TO_BCP[code]
+    else:
+      new_bcp = bcp
+      parts = bcp.split('-')
+      try:
+        script = generate_website_data.find_likely_script(parts[0])
+        if len(parts) == 1:
+          new_bcp = '%s-%s' % (bcp, script)
+        elif len(parts[1]) != 4 or parts[1].isdigit():
+          # assume a region or variant.  Some 4-char values are years, e.g. '1996'
+          new_bcp = '%s-%s-%s' % (parts[0], script, '-'.join(parts[1:]))
+        # otherwise, we assume the 4-char value is a script, and leave it alone.
+      except KeyError:
+        # if we can't provide a script, it's no use for a script sample, so exclude it
+        print 'no likely subtag (script) data for %s, excluding' % parts[0]
+        continue
+    result[new_bcp] = code
+  return result
+
+
+# These have been fixed in the noto repo.  We do not want to replace them with
+# the UDHR samples, which (as of now, anyway) do not reflect these improvements.
+EXCLUDE_BCP = frozenset([
+  'fa-Arab', 'ar-Arab'])
+
+# The data for these is bad.  The kwi.xml has no article 1 text (only '[?]')
+# and the cbi.xml article 1 text has '. mitya, tsenr)1in ' in it, which just looks
+# broken.
+EXCLUDE_CODES = frozenset([
+  'kwi', 'cbi'])
+
+def filter_bcp_to_code(bcp_to_code):
+  """Exclude entries for samples improved in noto/sample_texts and for bad samples."""
+  return {k: v for k, v in bcp_to_code.iteritems()
+          if k not in EXCLUDE_BCP and v not in EXCLUDE_CODES}
+
+
+def get_code_to_attrib(src_dir):
+  code_to_attrib = {}
+  code_file = 'ohchr_attributions.tsv'
+  with open(os.path.join(src_dir, code_file)) as f:
+    for line in f.readlines():
+      line = line.strip()
+      if not line or line.startswith('#'):
+        continue
+      code, attrib_key, lang, attrib = line.split('\t')
+      code_to_attrib[code] = attrib_key
+  return code_to_attrib
+
+
+def get_bcp_to_code_attrib(src_dir):
+  """Get the final bcp-to-code mapping."""
+  bcp_to_code, code_to_ohchr = parse_index(src_dir)
+  bcp_to_code = filter_bcp_to_code(add_likely_scripts(fix_index(bcp_to_code)))
+
+  code_to_attrib = get_code_to_attrib(src_dir)
+
+  bcp_to_code_attrib = {}
+  for bcp, code in bcp_to_code.iteritems():
+    ohchr = code_to_ohchr.get(code)
+    attr = code_to_attrib.get(ohchr)
+    if not attr:
+      attr = 'none'
+    bcp_to_code_attrib[bcp] = (code, attr)
+
+  return bcp_to_code_attrib
+
+
+def print_bcp_to_code_attrib(bcp_to_code):
+  print 'index size: %s' % len(bcp_to_code)
+  for bcp, (code, attrib) in sorted(bcp_to_code.iteritems()):
+    print '%s: %s, %s' % (bcp, code, attrib)
+
+
+def extract_para(src_path):
+  tree = ET.parse(src_path)
+  root = tree.getroot()
+  ns = {'udhr': 'http://www.unhchr.ch/udhr'}
+  article = root.find('udhr:article[@number="1"]', ns)
+  if article is None:
+    # file kjh.xml is damaged, arrgh. Cyrillic small 'ie' looks just like 'e', and
+    # the 'number' attribute is written with the Cyrillic e!
+    article = root.find(u'udhr:article[@numb\u0435r="1"]', ns)
+  if article is not None:
+    return ('\n'.join([para.text for para in article.findall('udhr:para', ns)])).strip() + '\n'
+  return None
+
+
+def fix_sample(sample, bcp):
+  """Fix samples that have known fixable issues, currently only Hans."""
+  new_sample = sample
+  if bcp == 'zh-Hans':
+    new_sample = sample.replace(u',', u'\uff0c')
+    if new_sample == sample:
+      print 'sample for %s was not changed' % bcp
+    else:
+      print 'changed sample for %s' % bcp
+  return new_sample
+
+
+def update_samples(sample_dir, udhr_dir, bcp_to_code_attrib, in_repo):
+  """Create samples in sample_dir from the sources in udhr_dir,
+  based on the bcp_to_code mapping.  Stage if sample_dir is in the
+  repo."""
+
+  tool_utils.check_dir_exists(udhr_dir)
+
+  if in_repo and os.path.isdir(sample_dir) and not tool_utils.git_is_clean(sample_dir):
+    raise ValueError('Please clean %s.' % sample_dir)
+
+  sample_attrib_list = [
+    '# Attributions for sample excerpts:\n',
+    '#   original - original, in the public domain\n',
+    '#   UN - UN, OHCHR, or affiliate\n',
+    '#   other - not UN or OHCHR, but on ohchr site\n',
+    '#   none - from unicode.org/udhr site, no attribution\n'
+  ]
+  sample_dir = tool_utils.ensure_dir_exists(sample_dir)
+  count = 0
+  for bcp, (code, attrib) in bcp_to_code_attrib.iteritems():
+    text = None
+    src_file = 'udhr_%s.xml' % code
+    dst_file = '%s.txt' % bcp
+    src_path = os.path.join(udhr_dir, src_file)
+    dst_path = os.path.join(sample_dir, dst_file)
+    sample = extract_para(src_path)
+    sample = fix_sample(sample, bcp)
+    if not sample:
+      print 'unable to get sample from %s' % src_file
+      return
+    else:
+      with codecs.open(dst_path, 'w', 'utf8') as f:
+        f.write(sample)
+      print 'created sample %s from %s' % (dst_file, src_file)
+      sample_attrib_list.append('%s: %s\n' % (bcp, attrib))
+      count += 1
+  print 'Created %d samples' % count
+
+  attrib_data = ''.join(sample_attrib_list)
+  with open(os.path.join(sample_dir, 'attributions.txt'), 'w') as f:
+    f.write(attrib_data)
+
+  if in_repo:
+    tool_utils.git_add_all(sample_dir)
+
+  date = datetime.datetime.now().strftime('%Y-%m-%d')
+  dst = 'in %s ' % sample_dir if not in_repo else ''
+  print 'Update sample files %sfrom %s as of %s.' % (dst, udhr_dir, date)
+
+
+def get_scripts(text):
+  """Return the set of scripts in this text.  Excludes
+  some common chars."""
+  # ignore these chars, we assume they are ok in any script
+  exclusions = {0x00, 0x0A, 0x0D, 0x20, 0xA0, 0xFEFF}
+  zyyy_chars = set()
+  scripts = set()
+  ustr = unicode(text, 'utf8')
+  for cp in ustr:
+    if ord(cp) in exclusions:
+      continue
+    script = unicode_data.script(cp)
+    if script == 'Zyyy': # common/undetermined
+      zyyy_chars.add(cp if cp < '\u00fe' else ord(cp))
+    elif not script == 'Zinh': # inherited
+      scripts.add(script)
+  return scripts, zyyy_chars
+
+
+# required, allowed sets
+SCRIPT_MAP = {
+    'Kore':(None, frozenset(['Hang'])),
+    'Jpan':(None, frozenset(['Hani', 'Hira'])),
+    'Hant':(None, frozenset(['Hani'])),
+    'Hans':(None, frozenset(['Hani']))}
+
+def accept_scripts(script):
+  if script in SCRIPT_MAP:
+    required, allowed = SCRIPT_MAP.get(script)
+  else:
+    required, allowed = frozenset([script]), None
+  return required, allowed
+
+
+def test_sample_scripts(sample_dir):
+  tested = 0
+  errors = 0
+  for filename in os.listdir(sample_dir):
+    filepath = os.path.join(sample_dir, filename)
+    if not (os.path.isfile(filepath) and filename.endswith('.txt')):
+      continue
+    tested += 1
+    with open(filepath, 'rb') as f:
+      textbytes = f.read()
+      scripts, zyyy = get_scripts(textbytes)
+      bcp = filename[:-len('.txt')] # trim off extension
+      expected_script = bcp.split('-')[1]
+      required, allowed = accept_scripts(expected_script)
+      if required and required - scripts:
+        required_name = ', '.join(sorted([s for s in required]))
+        scripts_name = ', '.join(sorted([s for s in scripts]))
+        print '%s requires %s but contains only %s' % (filename, required_name, scripts_name)
+        errors += 1
+      else:
+        remainder = scripts
+        if allowed:
+          remainder -= allowed
+        if required:
+          remainder -= required
+        if remainder:
+          allowed_name = ', '.join(sorted([s for s in allowed]))
+          scripts_name = ', '.join(sorted([s for s in scripts]))
+          print '%s allows %s but contains %s' % (filename, allowed_name, scripts_name)
+          errors += 1
+  print 'Found %d errors in %d files tested.' % (errors, tested)
+
+
+def compare_samples(src_dir, trg_dir, trg_to_src_name=lambda x: x, opts=None):
+  """Report on differences between samples in source and target directories.
+  The trg_to_src_name fn takes a target file name and returns the source
+  file name to use in the comparisons."""
+
+  if not os.path.isdir(src_dir):
+    print 'Original sample dir \'%s\' does not exist' % src_dir
+    return
+  if not os.path.isdir(trg_dir):
+    print 'New sample dir \'%s\' does not exist' % trg_dir
+    return
+
+  print 'Base dir: %s' % src_dir
+  print 'Target dir: %s' % trg_dir
+
+  show_missing = opts and 'missing' in opts
+  show_diffs = opts and 'diffs' in opts
+
+  for trg_name in os.listdir(trg_dir):
+    trg_path = os.path.join(trg_dir, trg_name)
+    if not (os.path.isfile(trg_path) and trg_name.endswith('.txt')):
+      continue
+
+    src_name = trg_to_src_name(trg_name)
+    src_path = os.path.join(src_dir, src_name)
+    if not os.path.exists(src_path):
+      if show_missing:
+        print 'source does not exist: %s' % src_name
+      continue
+
+    src_text = None
+    dst_text = None
+    with codecs.open(src_path, 'r', 'utf8') as f:
+      src_text = f.read()
+    with codecs.open(trg_path, 'r', 'utf8') as f:
+      trg_text = f.read()
+    if not src_text:
+      print 'source text (%s) is empty' % k
+      continue
+    if not trg_text:
+      print 'target text is empty: %s' % trg_path
+      continue
+    if src_text.find(trg_text) == -1:
+      print 'target (%s) text not in source (%s)' % (src_name, trg_name)
+      if show_diffs:
+        # In scripts that use space for word break it might be better to compare
+        # word by word, but this suffices.
+        sm = difflib.SequenceMatcher(None, src_text, trg_text, autojunk=False)
+        lines = []
+        for tag, i1, i2, j1, j2 in sm.get_opcodes():
+          if tag == 'delete':
+            lines.append('[%s/]' % src_text[i1:i2])
+          elif tag == 'equal':
+            lines.append(src_text[i1:i2])
+          elif tag == 'insert':
+            lines.append('[/%s]' % trg_text[j1:j2])
+          else:
+            lines.append('[%s/%s]' % (src_text[i1:i2], trg_text[j1:j2]))
+        print ''.join(lines)
+
+
+def update_repo(repo_samples, new_samples):
+  # Verify directory is clean.
+  if not tool_utils.git_is_clean(new_samples):
+    print 'Please fix.'
+    return
+
+  # Copy samples into git repo
+  for filename in os.listdir(new_samples):
+    filepath = os.path.join(new_samples, filename)
+    if not os.path.isfile(filepath):
+      continue
+    shutil.copy2(filename, repo_samples)
+
+  # Stage changes.
+  tool_utils.git_add_all(new_samples)
+
+  # Sample commit message.
+  print 'Update UDHR sample data.'
+
+
+def main():
+  values = notoconfig.values
+  noto = values.get('noto', None)
+  if noto:
+    noto = os.path.abspath(os.path.expanduser(noto))
+
+  fetch = '/tmp/udhr/zip'
+  udhr = '[noto]/third_party/udhr'
+  samples = '[noto]/sample_texts'
+
+  epilog = """The general flow is as follows:
+  1) first, use extract_ohchr_attributions.py to extract attribution data
+     to 'ohchr_attributions.tsv' and put into noto/third_party/udhr
+  2) use --uu to fetch and stage changes to noto/third_party/udhr
+  3) use --us --sample_dir=/tmp/foo to generate samples
+  4) use -c --sample_dir=/tmp/foo to compare the staged samples
+  5) tweak the mapping, use -m to see that it's doing what we want
+  6) use --us to generate the samples and stage them to noto/sample_texts
+  """
+
+  parser = argparse.ArgumentParser(epilog=epilog,
+    formatter_class=argparse.RawTextHelpFormatter)
+  parser.add_argument('--noto_dir', help='root of noto repo (default %s)' % noto,
+                      metavar='dir', default=noto)
+  parser.add_argument('--fetch_dir', help='directory into which to fetch xml.zip '
+                      '(default %s)' % fetch, metavar='dir', default=fetch)
+  parser.add_argument('--udhr_dir', help='location into which to unpack udhr files '
+                      '(default %s)' % udhr, metavar='dir', default=udhr)
+  parser.add_argument('--sample_dir', help='directory into which to extract samples '
+                      '(default %s)' % samples, metavar='dir', default=samples)
+  parser.add_argument('-f', '--fetch', help='fetch files from unicode.org/udhr to fetch dir',
+                      action='store_true')
+  parser.add_argument('-uu', '--update_udhr', help='unpack from fetched files to clean udhr dir\n'
+                      '(will stage if under noto)', action='store_true')
+  parser.add_argument('-us', '--update_sample', help='extract samples from udhr to sample dir, '
+                      'using the bcp to code mapping\n(will stage if under noto)',
+                      action='store_true')
+  parser.add_argument('-m', '--mapping', help='print the bcp to code mapping generated from the '
+                      'udhr dir', action='store_true')
+  parser.add_argument('-c', '--compare', help='compare sample changes from base dir '
+                      '(default %s)\nto sample dir' % samples,
+                      metavar='base_dir',  nargs='?', const=samples,
+                      dest='base_sample_dir')
+  parser.add_argument('-co', '--compare_opts', help='options for comparison, provide any of:\n'
+                      '  \'missing\' to show samples files not in base, and/or\n'
+                      '  \'diffs\' to show full diffs of samples',
+                      metavar='opt', nargs='+')
+  parser.add_argument('-ts', '--test_script', help='test script of samples in sample dir',
+                      action='store_true')
+
+  args = parser.parse_args()
+
+  # Check arguments
+
+  if not (args.fetch or args.update_udhr or args.update_sample or args.mapping
+          or args.base_sample_dir or args.test_script):
+    print 'nothing to do.'
+    return
+
+  if args.noto_dir:
+      args.noto_dir = os.path.realpath(os.path.abspath(os.path.expanduser(args.noto_dir)))
+
+  def fix_noto_prefix(argname):
+    noto_prefix = '[noto]/'
+    val = getattr(args, argname)
+    if val.startswith(noto_prefix):
+      if not args.noto_dir:
+        parser.error('%s depends on --noto_dir, which is not defined' % argname)
+      val = os.path.join(args.noto_dir, val[len(noto_prefix):])
+    setattr(args, argname, val)
+
+  if args.update_udhr or args.update_sample or args.mapping:
+    fix_noto_prefix('udhr_dir')
+
+  if args.update_sample or args.base_sample_dir or args.test_script:
+    fix_noto_prefix('sample_dir')
+
+  if args.base_sample_dir:
+    fix_noto_prefix('base_sample_dir')
+
+  if args.sample_dir == args.base_sample_dir:
+    parser.error('Compare is no-op when base and target sample dirs are the same.')
+
+  # Perform operations.  Some might still fail despite arg checks.
+  try:
+    if args.fetch:
+      fetch_udhr(args.fetch_dir)
+
+    if args.update_udhr:
+      in_repo = args.udhr_dir.startswith(args.noto_dir + '/')
+      update_udhr(args.udhr_dir, args.fetch_dir, in_repo)
+
+    if args.update_sample or args.mapping:
+      bcp_to_code_attrib = get_bcp_to_code_attrib(args.udhr_dir + '/')
+
+    if args.update_sample:
+      in_repo = args.sample_dir.startswith(args.noto_dir)
+      update_samples(args.sample_dir, args.udhr_dir, bcp_to_code_attrib, in_repo)
+
+    if args.mapping:
+      print_bcp_to_code_attrib(bcp_to_code_attrib)
+
+    if args.base_sample_dir:
+      compare_samples(args.base_sample_dir, args.sample_dir, opts=args.compare_opts)
+
+    if args.test_script:
+      test_sample_scripts(args.sample_dir)
+  except ValueError as e:
+      print 'Error:', e
+
+if __name__ == '__main__':
+    main()

--- a/nototools/update_udhr_samples.py
+++ b/nototools/update_udhr_samples.py
@@ -33,8 +33,8 @@ import urllib
 import xml.etree.ElementTree as ET
 import zipfile
 
-from nototools import notoconfig
-from nototools import tool_utils
+import notoconfig
+import tool_utils
 
 DIR_URL = 'http://unicode.org/udhr/d'
 UDHR_XML_ZIP_NAME = 'udhr_xml.zip'
@@ -264,7 +264,7 @@ def fix_sample(sample, bcp):
   if bcp == 'zh-Hans':
     new_sample = sample.replace(u',', u'\uff0c')
   elif bcp == 'hu-Latn':
-    new_sample = sample.replace(u'Minden.', y'Minden')
+    new_sample = sample.replace(u'Minden.', u'Minden')
 
   if not new_sample:
     return sample
@@ -528,7 +528,8 @@ def main():
     return
 
   def fix_noto_prefix(argname):
-    setattr(args, argname, tool_utils.resolve_path(getattr(args, argname)))
+    newval = tool_utils.resolve_path(getattr(args, argname))
+    setattr(args, argname, newval)
 
   if args.update_udhr or args.update_sample or args.mapping:
     fix_noto_prefix('udhr_dir')

--- a/nototools/update_udhr_samples.py
+++ b/nototools/update_udhr_samples.py
@@ -206,6 +206,49 @@ def filter_bcp_to_code(bcp_to_code):
           if k not in EXCLUDE_BCP and v not in EXCLUDE_CODES}
 
 
+# Pick a default sample to use when only lang and script are provided.
+OPTION_MAP = {
+    'ak-Latn': 'ak-Latn-asante',
+    'de-Latn': 'de-Latn-1996',
+    'el-Grek': 'el-Grek-monoton',
+    'ha-Latn': 'ha-Latn-NG',
+    'ht-Latn': 'ht-Latn-kreyol',
+    'ny-Latn': 'ny-Latn-chechewa',
+    'pt-Latn': 'pt-Latn-BR'
+}
+
+def add_default_lang_script(bcp_to_code):
+  """When we query this data, typically we have only language and script.  Some of
+  the bcp codes have variants or regions as well.  Select one of these to be the
+  default when we have only language and script."""
+
+  options = collections.defaultdict(set)
+  long_keys = {}
+  for key in bcp_to_code:
+    tags = key.split('-')
+    if len(tags) > 2:
+      long_keys[key] = tags
+  for key in sorted(long_keys):
+    tags = long_keys[key]
+    lang_scr = tags[0] + '-' + tags[1]
+    if lang_scr in bcp_to_code:
+      print 'have default for long tag %s: %s' % (key, bcp_to_code[lang_scr])
+    else:
+      options[lang_scr].add(key)
+  for lang_scr in sorted(options):
+    print '%s options: %s' % (lang_scr, options[lang_scr])
+    if not lang_scr in OPTION_MAP:
+      print 'missing from option map: %s' % lang_scr
+    elif not OPTION_MAP[lang_scr] in options[lang_scr]:
+      print 'selected option for %s (%s) not available' % (
+          lang_scr, OPTION_MAP[lang_scr])
+    else:
+      value = bcp_to_code[OPTION_MAP[lang_scr]]
+      print 'adding %s for %s' % (value, lang_scr)
+      bcp_to_code[lang_scr] = value
+  return bcp_to_code
+
+
 def get_code_to_attrib(src_dir):
   code_to_attrib = {}
   code_file = 'attributions.tsv'
@@ -223,6 +266,7 @@ def get_bcp_to_code_attrib(src_dir, ohchr_dir):
   """Get the final bcp-to-code mapping."""
   bcp_to_code, code_to_ohchr = parse_index(src_dir)
   bcp_to_code = filter_bcp_to_code(add_likely_scripts(fix_index(bcp_to_code)))
+  bcp_to_code = add_default_lang_script(bcp_to_code)
 
   code_to_attrib = get_code_to_attrib(ohchr_dir)
 
@@ -287,13 +331,14 @@ def update_samples(sample_dir, udhr_dir, bcp_to_code_attrib, in_repo):
   if in_repo and os.path.isdir(sample_dir) and not tool_utils.git_is_clean(sample_dir):
     raise ValueError('Please clean %s.' % sample_dir)
 
-  sample_attrib_list = [
-    '# Attributions for sample excerpts:\n',
-    '#   original - original, in the public domain\n',
-    '#   UN - UN, OHCHR, or affiliate\n',
-    '#   other - not UN or OHCHR, but on ohchr site\n',
-    '#   none - from unicode.org/udhr site, no attribution\n'
+  comments = [
+    '# Attributions for sample excerpts:',
+    '#   original - in the public domain, no attribution',
+    '#   UN - UN, OHCHR, or affiliate, attribute to UN',
+    '#   other - not a UN translation',
+    '#   none - not on ohchr, not a UN translation'
   ]
+  sample_attrib_list = []
   sample_dir = tool_utils.ensure_dir_exists(sample_dir)
   count = 0
   for bcp, (code, attrib) in bcp_to_code_attrib.iteritems():
@@ -311,11 +356,10 @@ def update_samples(sample_dir, udhr_dir, bcp_to_code_attrib, in_repo):
       with codecs.open(dst_path, 'w', 'utf8') as f:
         f.write(sample)
       print 'created sample %s from %s' % (dst_file, src_file)
-      sample_attrib_list.append('%s: %s\n' % (bcp, attrib))
+      sample_attrib_list.append('%s: %s' % (bcp, attrib))
       count += 1
   print 'Created %d samples' % count
-
-  attrib_data = ''.join(sample_attrib_list)
+  attrib_data = '\n'.join(comments + sorted(sample_attrib_list))
   with open(os.path.join(sample_dir, 'attributions.txt'), 'w') as f:
     f.write(attrib_data)
 
@@ -501,9 +545,9 @@ def main():
   parser.add_argument('-f', '--fetch', help='fetch files from unicode.org/udhr to fetch dir',
                       action='store_true')
   parser.add_argument('-uu', '--update_udhr', help='unpack from fetched files to clean udhr dir\n'
-                      '(will stage if in repo)', action='store_true')
+                      '(will stage if in repo and not no_stage)', action='store_true')
   parser.add_argument('-us', '--update_sample', help='extract samples from udhr to sample dir, '
-                      'using the bcp to code mapping\n(will stage if in repo)',
+                      'using the bcp to code mapping\n(will stage if in repo and not no_stage)',
                       action='store_true')
   parser.add_argument('-m', '--mapping', help='print the bcp to code mapping generated from the '
                       'udhr dir', action='store_true')
@@ -517,6 +561,7 @@ def main():
                       metavar='opt', nargs='+')
   parser.add_argument('-ts', '--test_script', help='test script of samples in sample dir',
                       action='store_true')
+  parser.add_argument('-n', '--no_stage', help='do not stage changes in repo', action='store_true')
 
   args = parser.parse_args()
 
@@ -550,7 +595,7 @@ def main():
 
     if args.update_udhr:
       in_repo = args.udhr_dir == tool_utils.resolve_path(udhr)
-      update_udhr(args.udhr_dir, args.fetch_dir, in_repo)
+      update_udhr(args.udhr_dir, args.fetch_dir, in_repo and not args.no_stage)
 
     if args.update_sample or args.mapping:
       ohchr_dir = tool_utils.resolve_path('[tools]/third_party/ohchr')
@@ -558,7 +603,8 @@ def main():
 
     if args.update_sample:
       in_repo = args.sample_dir == tool_utils.resolve_path(samples)
-      update_samples(args.sample_dir, args.udhr_dir, bcp_to_code_attrib, in_repo)
+      update_samples(args.sample_dir, args.udhr_dir, bcp_to_code_attrib,
+                     in_repo and not args.no_stage)
 
     if args.mapping:
       print_bcp_to_code_attrib(bcp_to_code_attrib)

--- a/third_party/ohchr/ohchr_all.html
+++ b/third_party/ohchr/ohchr_all.html
@@ -1,0 +1,3881 @@
+<html>
+<head>
+</head>
+<body>
+<-- See comments in nototools/extract_ohchr_attributions.py for information on the origin and
+purpose of this file. -->
+<table id='ohchr_alldata'>
+	<tr>
+		<th scope="col" class="UDHRHeader">
+            <tr>
+                <th style="width:15%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID1">Translation</span>   </th>
+                <!-- th style="width:20%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID2">Region</span>   </!-->
+                <th style="width:55%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID3">Translation Source</span></th>
+          </tr>
+     </th>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_hpLangTitleID" href="Language.aspx?LangID=abk">Abkhaz</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblSourceID">Office of the High Commissioner for Human Rights - Georgia Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_hpLangTitleID" href="Language.aspx?LangID=atj">Achehnese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblSourceID">Asnawi Ali</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_hpLangTitleID" href="Language.aspx?LangID=jiv">Achuar Chicham</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_hpLangTitleID" href="Language.aspx?LangID=acu">Achuar-Shiwiar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_hpLangTitleID" href="Language.aspx?LangID=ajg">Adja</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblSourceID">Commission béninoise des Droits de l'Homme, Benin</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_hpLangTitleID" href="Language.aspx?LangID=ady">Adyghe</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblSourceID">Federation of Caucasian Assocations in Turkey (Kaffed)</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_hpLangTitleID" href="Language.aspx?LangID=gax">Afaan Oromo (Oromiffa)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblSourceID">Dema Translation and Editing Service</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_hpLangTitleID" href="Language.aspx?LangID=afk">Afrikaans</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblSourceID">United Nations Information Centre, Namibia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_hpLangTitleID" href="Language.aspx?LangID=agr">Aguaruna</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_hpLangTitleID" href="Language.aspx?LangID=ccc">A'ingae</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_hpLangTitleID" href="Language.aspx?LangID=tws1">Akuapem Twi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblSourceID">National Association of Negro Business and Professional Women's Clubs, US</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_hpLangTitleID" href="Language.aspx?LangID=aln">Albanian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_hpLangTitleID" href="Language.aspx?LangID=alt">Altay</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_hpLangTitleID" href="Language.aspx?LangID=amc">Amahuaca</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_hpLangTitleID" href="Language.aspx?LangID=amr">Amarakaeri</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_hpLangTitleID" href="Language.aspx?LangID=ama">Amazigh</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblSourceID">Réseau Amazigh pour la Citoyenneté</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_hpLangTitleID" href="Language.aspx?LangID=amh">Amharic</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblSourceID">National Commission for UNESCO, Ethiopia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_hpLangTitleID" href="Language.aspx?LangID=ame">Amuesha-Yanesha</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_hpLangTitleID" href="Language.aspx?LangID=njo">Ao</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_hpLangTitleID" href="Language.aspx?LangID=arl">Arabela</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_hpLangTitleID" href="Language.aspx?LangID=arz">Arabic (Alarabia)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_hpLangTitleID" href="Language.aspx?LangID=arm">Armenian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_hpLangTitleID" href="Language.aspx?LangID=ass">Asante</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblSourceID">National Association of Negro Business and Professional Women's Clubs, US</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_hpLangTitleID" href="Language.aspx?LangID=cni">Asháninca</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_hpLangTitleID" href="Language.aspx?LangID=cpu">Ashéninca</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_hpLangTitleID" href="Language.aspx?LangID=asm">Assamese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_hpLangTitleID" href="Language.aspx?LangID=aii">Assyrian (Atoraya)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblSourceID">Journal of Assyrian Academic Studies, USA (Philimon Darmo)</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_hpLangTitleID" href="Language.aspx?LangID=aub">Asturian (Bable)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblSourceID">Academia de la Llingua Asturiana, Spain</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_hpLangTitleID" href="Language.aspx?LangID=awa">Awadhi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_hpLangTitleID" href="Language.aspx?LangID=kwi">Awapit</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_hpLangTitleID" href="Language.aspx?LangID=aym">Aymara</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_hpLangTitleID" href="Language.aspx?LangID=azb1">Azeri/Azerbaijani (Cyrillic)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_hpLangTitleID" href="Language.aspx?LangID=azb">Azeri/Azerbaijani (Latin)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_hpLangTitleID" href="Language.aspx?LangID=aub">Bable (Asturian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblSourceID">Academia de la Llingua Asturiana, Spain</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_hpLangTitleID" href="Language.aspx?LangID=inz">Bahasa Indonesia</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_hpLangTitleID" href="Language.aspx?LangID=mli">Bahasa Melayu (Malay)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_hpLangTitleID" href="Language.aspx?LangID=1121">Bai Coca</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_hpLangTitleID" href="Language.aspx?LangID=bvi">Balanda Viri</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblSourceID">United Nations Mission In Sudan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_hpLangTitleID" href="Language.aspx?LangID=bzc">Balinese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_hpLangTitleID" href="Language.aspx?LangID=bgp">Balochi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblSourceID">United Nations Information Centre, Pakistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_hpLangTitleID" href="Language.aspx?LangID=bra">Bambara</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with l'Agence de Coopération Culturelle et Technique</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_hpLangTitleID" href="Language.aspx?LangID=bci">Baoulé/Baule</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_hpLangTitleID" href="Language.aspx?LangID=brd">Baram</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblSourceID">Nepal Baram Association</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_hpLangTitleID" href="Language.aspx?LangID=bfa">Bari</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblSourceID">United Nations Mission In Sudan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_hpLangTitleID" href="Language.aspx?LangID=bsq">Basque (Euskara)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblSourceID">United Nations Information Centre, Spain</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_hpLangTitleID" href="Language.aspx?LangID=bba">Batonu (Bariba)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblSourceID">Commission béniniose des Droits de l'Homme</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_hpLangTitleID" href="Language.aspx?LangID=ruw">Belorus (Belaruski)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblSourceID">Permanent Mission of the Republic of Belarus to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_hpLangTitleID" href="Language.aspx?LangID=bem">Bemba</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_hpLangTitleID" href="Language.aspx?LangID=bng">Bengali</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_hpLangTitleID" href="Language.aspx?LangID=btb">Béti</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblSourceID">United Nations Information Centre, Cameroon</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_hpLangTitleID" href="Language.aspx?LangID=bhj">Bhojpuri</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblSourceID">United Nations Information Centre, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_hpLangTitleID" href="Language.aspx?LangID=bcy">Bichelamar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_hpLangTitleID" href="Language.aspx?LangID=bkl">Bikol/Bicolano</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblSourceID">Carpio Center for Human Rights, The Philippines</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_hpLangTitleID" href="Language.aspx?LangID=boa">Bora</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_hpLangTitleID" href="Language.aspx?LangID=src4">Bosnian (Cyrillic script)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblSourceID">United Nations Mission In Bosnia and Herzegovina</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_hpLangTitleID" href="Language.aspx?LangID=src1">Bosnian (Latin script)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblSourceID">United Nations Mission In Bosnia and Herzegovina</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_hpLangTitleID" href="Language.aspx?LangID=brt">Breton</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_hpLangTitleID" href="Language.aspx?LangID=bpr">Bugisnese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_hpLangTitleID" href="Language.aspx?LangID=blg">Bulgarian (Balgarski)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblSourceID">United Nations Information Centre, Bulgaria</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_hpLangTitleID" href="Language.aspx?LangID=bms">Burmese/Myanmar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblSourceID">United Nations Information Centre, Myanmar</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_hpLangTitleID" href="Language.aspx?LangID=cak1">Cakchiquel</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblSourceID">Instituto de Linguistica, Argentina</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_hpLangTitleID" href="Language.aspx?LangID=cpp">Campa pajonalino</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_hpLangTitleID" href="Language.aspx?LangID=cbu">Candoshi-Shapra</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_hpLangTitleID" href="Language.aspx?LangID=cot">Caquinte</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_hpLangTitleID" href="Language.aspx?LangID=cbr">Cashibo-Cacataibo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_hpLangTitleID" href="Language.aspx?LangID=cbs">Cashinahua</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_hpLangTitleID" href="Language.aspx?LangID=cln">Catalan (Català)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblSourceID">United Nations Information Centre, Spain</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_hpLangTitleID" href="Language.aspx?LangID=ceb">Cebuano</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblSourceID">United Nations Information Centre, The Philippines</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_hpLangTitleID" href="Language.aspx?LangID=1122">Chaa'pala</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_hpLangTitleID" href="Language.aspx?LangID=cjd">Chamorro</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_hpLangTitleID" href="Language.aspx?LangID=tso">Changane (Mozambique)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_hpLangTitleID" href="Language.aspx?LangID=chx">Chantyal</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblSourceID">Nepal Chhantyal Association</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_hpLangTitleID" href="Language.aspx?LangID=cbt">Chayahuita</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_hpLangTitleID" href="Language.aspx?LangID=nyj1">Chechewa (Nyanja)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_hpLangTitleID" href="Language.aspx?LangID=hne">Chhattisgarhi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_hpLangTitleID" href="Language.aspx?LangID=cic">Chickasaw</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_lblSourceID">Catherine Willmond and Pamela Munro (University of California, Los Angeles, US)</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_hpLangTitleID" href="Language.aspx?LangID=fal">Chin Falam</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_lblSourceID">United Nations Department of Public Information, Myanmar</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_hpLangTitleID" href="Language.aspx?LangID=hak">Chin Hakha</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_lblSourceID">United Nations Department of Public Information, Myanmar</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_hpLangTitleID" href="Language.aspx?LangID=hlt">Chin Matu (Nga La)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_lblSourceID">Chin Human Rights Organization</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_hpLangTitleID" href="Language.aspx?LangID=tid">Chin Tiddim</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_lblSourceID">United Nations Department of Public Information, Myanmar</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_hpLangTitleID" href="Language.aspx?LangID=csa">Chinanteco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_lblSourceID">United Nations Department of Public Information, NY, in cooperation with the Ministry of Education, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_hpLangTitleID" href="Language.aspx?LangID=chj">Chinanteco, Ajitlán</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_hpLangTitleID" href="Language.aspx?LangID=chn">Chinese (Mandarin)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_hpLangTitleID" href="Language.aspx?LangID=cax">Chiquitano</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_lblSourceID">Office of the High Commissioner for Human Rights - Bolivia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_hpLangTitleID" href="Language.aspx?LangID=tru1">Chuuk (Trukese)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_hpLangTitleID" href="Language.aspx?LangID=cjk">Cokwe</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Angola</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_hpLangTitleID" href="Language.aspx?LangID=coi">Corsican</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_hpLangTitleID" href="Language.aspx?LangID=kea">Crioulo (Cabo Verde)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_hpLangTitleID" href="Language.aspx?LangID=gbc">Crioulo da Guiné-Bissau (Guinea Bissau Creole)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_hpLangTitleID" href="Language.aspx?LangID=src2">Croatian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_lblSourceID">Permanent Mission of the Republic of Croatia to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_hpLangTitleID" href="Language.aspx?LangID=wls">Cymraeg (Welsh)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_lblSourceID">United Nations Association, Wales</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl92_hpLangTitleID" href="Language.aspx?LangID=czc">Czech (Cesky)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl92_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl92_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl93_hpLangTitleID" href="Language.aspx?LangID=dga">Dagaare</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl93_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl93_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl94_hpLangTitleID" href="Language.aspx?LangID=dag">Dagbani</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl94_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl94_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl95_hpLangTitleID" href="Language.aspx?LangID=gac1">Dangme</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl95_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl95_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl96_hpLangTitleID" href="Language.aspx?LangID=dns">Danish (Dansk)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl96_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl96_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl97_hpLangTitleID" href="Language.aspx?LangID=dhw">Danuwar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl97_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl97_lblSourceID">Danuwar Jagaran Samiti</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl98_hpLangTitleID" href="Language.aspx?LangID=prs1">Dari</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl98_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl98_lblSourceID">Cooperation Centre for Afghanistan and UNDP/UNOCHA, Pakistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl99_hpLangTitleID" href="Language.aspx?LangID=den">Dendi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl99_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl99_lblSourceID">Commission béniniose des Droits de l'Homme</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl100_hpLangTitleID" href="Language.aspx?LangID=div">Dhivehi (Maldivian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl100_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl100_lblSourceID">Human Rights Commission of the Maldives, Maldives</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl101_hpLangTitleID" href="Language.aspx?LangID=nav">Dine, Navajo (Navaho)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl101_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl101_lblSourceID">Navajo Interpreting Services, US</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl102_hpLangTitleID" href="Language.aspx?LangID=dinka">Dinka</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl102_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl102_lblSourceID">United Nations Mission In Sudan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl103_hpLangTitleID" href="Language.aspx?LangID=dyo">Diola (Jola-Fogny)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl103_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl103_lblSourceID">Tostan, Senegal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl104_hpLangTitleID" href="Language.aspx?LangID=dyu">Dioula</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl104_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl104_lblSourceID">United Nations Operation in Cote d'Ivoire</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl105_hpLangTitleID" href="Language.aspx?LangID=tbz">Ditammari</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl105_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl105_lblSourceID">Commission béninoise des Droits de l'Homme, Benin</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl106_hpLangTitleID" href="Language.aspx?LangID=dut">Dutch (Nederlands)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl106_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl106_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl107_hpLangTitleID" href="Language.aspx?LangID=dzo">Dzongkha/Bhutanese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl107_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl107_lblSourceID">United Nations Information Centre, India</span></td>
+          </tr>
+      </td>
+	</tr>
+	<tr>
+		<th scope="col" class="UDHRHeader">
+            <tr>
+                <th style="width:15%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID1">Translation</span>   </th>
+                <!-- th style="width:20%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID2">Region</span>   </!-->
+                <th style="width:55%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID3">Translation Source</span></th>
+          </tr>
+     </th>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_hpLangTitleID" href="Language.aspx?LangID=edo">Edo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_hpLangTitleID" href="Language.aspx?LangID=ibb">Efik (Ibibio)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_hpLangTitleID" href="Language.aspx?LangID=grk">Ellinika' (Greek)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblSourceID">United Nations Information Centre, Greece</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_hpLangTitleID" href="Language.aspx?LangID=eng">English</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_hpLangTitleID" href="Language.aspx?LangID=spn">Español (Spanish)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_hpLangTitleID" href="Language.aspx?LangID=1115">Esperanto</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblRegionID">International</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblSourceID">Universala Esperanto Asocio Rotterdam, The Netherlands</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_hpLangTitleID" href="Language.aspx?LangID=est">Estonian (Eesti)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblSourceID">Estonian Human Rights Institute, Estonia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_hpLangTitleID" href="Language.aspx?LangID=bsq">Euskara (Basque)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblSourceID">United Nations Information Centre, Spain</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_hpLangTitleID" href="Language.aspx?LangID=eve">Even</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_hpLangTitleID" href="Language.aspx?LangID=evn">Evenki</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_hpLangTitleID" href="Language.aspx?LangID=ewe">Ewe/Eve</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_hpLangTitleID" href="Language.aspx?LangID=tws3">Fante</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_hpLangTitleID" href="Language.aspx?LangID=fae">Faroese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_hpLangTitleID" href="Language.aspx?LangID=prs">Farsi/Persian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblSourceID">United Nations Information Centre, Iran</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_hpLangTitleID" href="Language.aspx?LangID=fji">Fijian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblSourceID">United Nations Development Programme, Fiji</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_hpLangTitleID" href="Language.aspx?LangID=tgl">Filipino (Tagalog)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_hpLangTitleID" href="Language.aspx?LangID=fin">Finnish</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_hpLangTitleID" href="Language.aspx?LangID=kng">Fiote (Angola)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_hpLangTitleID" href="Language.aspx?LangID=foa">Fon</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblSourceID">Commission béninoise des Droits de l'Homme, Benin</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_hpLangTitleID" href="Language.aspx?LangID=1128">Forro</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_hpLangTitleID" href="Language.aspx?LangID=Fr3">Francoprovençal, Fribourg</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblSourceID">Anne-Marie Yerly</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_hpLangTitleID" href="Language.aspx?LangID=fr2">Francoprovençal, Savoie</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblSourceID">Anne-Marie Bimet</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_hpLangTitleID" href="Language.aspx?LangID=frp">Francoprovençal, Valais</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblSourceID">Alphonse Dayer</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_hpLangTitleID" href="Language.aspx?LangID=fr4">Francoprovençal, Vaud</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblSourceID">Marie-Louise Goumaz</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_hpLangTitleID" href="Language.aspx?LangID=frn">French (Français)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_hpLangTitleID" href="Language.aspx?LangID=fri">Frisian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblSourceID">United Nations Information Centre, Belgium</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_hpLangTitleID" href="Language.aspx?LangID=frl">Friulian (Friulano)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblSourceID">Associazione Proiezione Peters, Italy</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_hpLangTitleID" href="Language.aspx?LangID=gac2">Ga</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_hpLangTitleID" href="Language.aspx?LangID=gli1">Gaeilge (Irish Gaelic)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_hpLangTitleID" href="Language.aspx?LangID=gag">Gagauz</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_hpLangTitleID" href="Language.aspx?LangID=gls">Gàidhlig Albanach (Scottish Gaelic)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_hpLangTitleID" href="Language.aspx?LangID=gln">Galician (Galego)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblSourceID">United Nations Information Centre, Spain, in cooperation with the Dirección Xeral de Política Lingnistica de la Consellería de Educación y Ordenación Universitaria de la Xunta de Galicia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_hpLangTitleID" href="Language.aspx?LangID=gbm">Garhwali</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_hpLangTitleID" href="Language.aspx?LangID=cab">Garifuna</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_hpLangTitleID" href="Language.aspx?LangID=geo">Georgian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblSourceID">Caucasian Institute, Georgia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_hpLangTitleID" href="Language.aspx?LangID=ger">German (Deutsch)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblSourceID">UN Department for General Assembly and Conference Management German Translation Service, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_hpLangTitleID" href="Language.aspx?LangID=gno">Gondi, Northern</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_hpLangTitleID" href="Language.aspx?LangID=dum">Gonja</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_hpLangTitleID" href="Language.aspx?LangID=grk">Greek (Ellinika')</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblSourceID">United Nations Information Centre, Greece</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_hpLangTitleID" href="Language.aspx?LangID=esg">Greenlandic (Inuktikut)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_hpLangTitleID" href="Language.aspx?LangID=gun">Guarani</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblSourceID">Consejo Indio de Sur America, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_hpLangTitleID" href="Language.aspx?LangID=gua">Guarayo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblSourceID"></span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_hpLangTitleID" href="Language.aspx?LangID=hna">Guen (Mina)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblSourceID">Commission béninoise des Droits de l'Homme, Benin</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_hpLangTitleID" href="Language.aspx?LangID=gjr">Gujarati</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_hpLangTitleID" href="Language.aspx?LangID=gvr">Gurung</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblSourceID">Tamu Hyula Chhojdhin</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_hpLangTitleID" href="Language.aspx?LangID=hat">Haitian Creole (Kreyol)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_hpLangTitleID" href="Language.aspx?LangID=hat1">Haitian Creole (popular)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblSourceID">United Nations Development Programme, Haiti</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_hpLangTitleID" href="Language.aspx?LangID=hni">Hani</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_hpLangTitleID" href="Language.aspx?LangID=kkn">Hankuko (Korean)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Paris</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_hpLangTitleID" href="Language.aspx?LangID=gej">Hausa/Haoussa</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with l'Agence de Coopération Culturelle et Technique</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_hpLangTitleID" href="Language.aspx?LangID=hwi">Hawaiian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblSourceID">Hawaii Institute for Human Rights, US</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_hpLangTitleID" href="Language.aspx?LangID=hbr">Hebrew</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblSourceID">Permanent Mission of Israel to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_hpLangTitleID" href="Language.aspx?LangID=hil">Hiligaynon</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblSourceID">United Nations Information Centre, The Philippines</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_hpLangTitleID" href="Language.aspx?LangID=hnd">Hindi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_hpLangTitleID" href="Language.aspx?LangID=hea">Hmong (Miao) Northern East-Guizhou</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_hpLangTitleID" href="Language.aspx?LangID=hms">Hmong (Miao) Southern East-Guizhou</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_hpLangTitleID" href="Language.aspx?LangID=blu">Hmong (Miao), Sichuan-Guizhou-Yunnan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_hpLangTitleID" href="Language.aspx?LangID=Hoc">Ho</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_hpLangTitleID" href="Language.aspx?LangID=src2">Hrvatski (Croatian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblSourceID">Permanent Mission of the Republic of Croatia to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_hpLangTitleID" href="Language.aspx?LangID=hus">Huastec, Veracruz</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblSourceID">Comisión de Derechos Humanos del Estado de Veracruz</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_hpLangTitleID" href="Language.aspx?LangID=hva">Huasteco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblSourceID">United Nations Information Centre, Mexico in cooperation with the National Human Rights Commission Indigena</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_hpLangTitleID" href="Language.aspx?LangID=huu">Huitoto Murui</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblSourceID">Ministerio de Educacion, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_hpLangTitleID" href="Language.aspx?LangID=hng">Hungarian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_hpLangTitleID" href="Language.aspx?LangID=scp">Hyolmo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblSourceID">Nepal Hyolmo Social Service Association</span></td>
+          </tr>
+      </td>
+	</tr>
+	<tr>
+		<th scope="col" class="UDHRHeader">
+            <tr>
+                <th style="width:15%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID1">Translation</span>   </th>
+                <!-- th style="width:20%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID2">Region</span>   </!-->
+                <th style="width:55%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID3">Translation Source</span></th>
+          </tr>
+     </th>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_hpLangTitleID" href="Language.aspx?LangID=ibb">Ibibio</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_hpLangTitleID" href="Language.aspx?LangID=ice">Icelandic (íslenska)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_hpLangTitleID" href="Language.aspx?LangID=1120">Ido</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblRegionID">International</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblSourceID">International Language Ido, Germany</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_hpLangTitleID" href="Language.aspx?LangID=igr">Igbo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with l'Agence de Coopération Culturelle et Technique</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_hpLangTitleID" href="Language.aspx?LangID=ilo">Iloko/Ilocano</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblSourceID">Commission on Human Rights, The Philippines</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_hpLangTitleID" href="Language.aspx?LangID=inz">Indonesian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_hpLangTitleID" href="Language.aspx?LangID=1119">Interlingua</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblRegionID">International</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblSourceID">Union Mundial pro Interlingua, The Netherlands</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_hpLangTitleID" href="Language.aspx?LangID=esg">Inuktikut (Greenlandic)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_hpLangTitleID" href="Language.aspx?LangID=esb">Inuktitut</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblSourceID">Permanent Mission of Canada to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_hpLangTitleID" href="Language.aspx?LangID=gli1">Irish Gaelic</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_hpLangTitleID" href="Language.aspx?LangID=itn">Italian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblSourceID">United Nations Information Centre, Italy</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_hpLangTitleID" href="Language.aspx?LangID=hbr">Ivrit (Hebrew)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblSourceID">Permanent Mission of Israel to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_hpLangTitleID" href="Language.aspx?LangID=jpn">Japanese (Nihongo)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblSourceID">United Nations Information Centre, Japan, and the Ministry of Justice and Human Rights NGOs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_hpLangTitleID" href="Language.aspx?LangID=jan">Javanese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_hpLangTitleID" href="Language.aspx?LangID=jul">Jirel</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblSourceID">Jirel Association Nepal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_hpLangTitleID" href="Language.aspx?LangID=maz">Jñatrjo (Mazahua)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblSourceID">United Nations Information Centre, Mexico, in cooperation with the Ministry of Education</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_hpLangTitleID" href="Language.aspx?LangID=dyo">Jola-Fogny (Diola)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblSourceID">Tostan, Senegal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_hpLangTitleID" href="Language.aspx?LangID=kbd">Kabardian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblSourceID">Federation of Caucasian Assocations in Turkey (Kaffed)</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_hpLangTitleID" href="Language.aspx?LangID=kbp">Kabyè</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblSourceID">United Nations Information Centre, Togo</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_hpLangTitleID" href="Language.aspx?LangID=bjj">Kanauji</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_hpLangTitleID" href="Language.aspx?LangID=kjv">Kannada</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblSourceID">Former OHCHR Intern</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_hpLangTitleID" href="Language.aspx?LangID=kph">Kanuri Yerwa</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_hpLangTitleID" href="Language.aspx?LangID=kqn">Kaonde</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_hpLangTitleID" href="Language.aspx?LangID=pmp">Kapampangan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblSourceID">Komisyon ng Karapatang Pantao, The Philippines</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_hpLangTitleID" href="Language.aspx?LangID=krl">Karelian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_hpLangTitleID" href="Language.aspx?LangID=pwo">Karen (Pwo)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblSourceID">United Nations Information Centre, Burma</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_hpLangTitleID" href="Language.aspx?LangID=ksw">Karen (S'gaw)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblSourceID">United Nations Information Centre, Burma</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_hpLangTitleID" href="Language.aspx?LangID=kas">Kasem</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_hpLangTitleID" href="Language.aspx?LangID=ksh">Kashmiri</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblSourceID">United Nations Information Centre, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_hpLangTitleID" href="Language.aspx?LangID=kaz">Kazakh</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblSourceID">United Nations Department of Public Information, Kazakhstan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_hpLangTitleID" href="Language.aspx?LangID=kjh">Khakas</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_hpLangTitleID" href="Language.aspx?LangID=khk">Khalkha (Mongolian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblSourceID">CHR Technical Cooperation Branch, Mongolia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_hpLangTitleID" href="Language.aspx?LangID=khr">Kharia</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_hpLangTitleID" href="Language.aspx?LangID=kha">Khasi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblSourceID">Meghalaya Peoples Human Rights Council</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_hpLangTitleID" href="Language.aspx?LangID=khm">Khmer</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblSourceID">Cambodia Documentation Commission, Cambodia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_hpLangTitleID" href="Language.aspx?LangID=buc">Kibushi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblSourceID">Service linguistique du Conseil Général de Mayotte</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_hpLangTitleID" href="Language.aspx?LangID=1117">K'iche' (Quiché)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblSourceID">Instituto de Linguistica, Argentina</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_hpLangTitleID" href="Language.aspx?LangID=qug">Kichwa</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_hpLangTitleID" href="Language.aspx?LangID=kon">Kikongo ya L'Etat (Kikongo/Kituba)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblSourceID">Office of the High Commissioner for Human Rights - Congo Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_hpLangTitleID" href="Language.aspx?LangID=mlo">Kimbundu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Angola</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_hpLangTitleID" href="Language.aspx?LangID=nyz">Kinyamwezi (Nyamwezi)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblSourceID">United Nations Development Programme, Tanzania</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_hpLangTitleID" href="Language.aspx?LangID=rua1">Kinyarwanda</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_hpLangTitleID" href="Language.aspx?LangID=kis">Kisan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblSourceID">Kisan Community Development Foundation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_hpLangTitleID" href="Language.aspx?LangID=suz">Koits-Sunuwar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblSourceID">Sunuwar Welfare Society</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_hpLangTitleID" href="Language.aspx?LangID=koi">Komi-Permian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_hpLangTitleID" href="Language.aspx?LangID=kkn">Korean (Hankuko)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Paris</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_hpLangTitleID" href="Language.aspx?LangID=kou">Koulango</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblSourceID">United Nations Operation in Cote d'Ivoire</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_hpLangTitleID" href="Language.aspx?LangID=gkp1">Kpelewo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblSourceID">Ministère de l'Education Nationale, Guinea</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_hpLangTitleID" href="Language.aspx?LangID=hat">Kreyol (Haitian Creole)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_hpLangTitleID" href="Language.aspx?LangID=kri">Krio</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblSourceID">National Commission for Democracy and Human Rights, Sierra Leone</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_hpLangTitleID" href="Language.aspx?LangID=kdb1">Kurdish</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblSourceID">Kurdish Institute, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_hpLangTitleID" href="Language.aspx?LangID=kur">Kurmanji</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblSourceID">United Nations Development Programme, Iraq</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_hpLangTitleID" href="Language.aspx?LangID=kfa">Kurug</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_hpLangTitleID" href="Language.aspx?LangID=kdo">Kyrgyz</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblSourceID">Permanent Mission of the Kyrgyz Republic to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_hpLangTitleID" href="Language.aspx?LangID=lld">Ladin</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblRegionID"></span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblSourceID">Office for Language Issues and Press Office of the Autonomous Province of Bolzano/Bozen/Balsan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_hpLangTitleID" href="Language.aspx?LangID=lad">Ladino</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblSourceID">Ladinokomunita</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_hpLangTitleID" href="Language.aspx?LangID=nso">Lamnso' (Lám nso')</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblSourceID">Executive Committee of the Nso' Language Organisation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_hpLangTitleID" href="Language.aspx?LangID=nol">Lao</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_hpLangTitleID" href="Language.aspx?LangID=ltn">Latin (Latina)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblSourceID">Classes 3AB1 - 3B2 Gymnase de Nyon, Suisse</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_hpLangTitleID" href="Language.aspx?LangID=ltn1">Latin (Latina)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblSourceID">Liceo Ginnasio Statale "Socrate" Rome, Italy</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_hpLangTitleID" href="Language.aspx?LangID=lat">Latvian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblSourceID">Human Rights Institute of the University of Latvia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_hpLangTitleID" href="Language.aspx?LangID=lhm">Lhomi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblSourceID">Lhomi (Shingsa) Kalyan Kendra and Nepal Lhomi Society</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_hpLangTitleID" href="Language.aspx?LangID=lij">Ligurian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblSourceID">A Compagna di Zoeni</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_hpLangTitleID" href="Language.aspx?LangID=lia">Limba</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblSourceID">National Commission for Democracy and Human Rights, Sierra Leone</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_hpLangTitleID" href="Language.aspx?LangID=lif">Limbu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblSourceID">Kirat Yakthung Chumlung</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_hpLangTitleID" href="Language.aspx?LangID=lin">Lingala</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblSourceID">United Nations Information Centre, Democratic Republic of the Congo</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_hpLangTitleID" href="Language.aspx?LangID=lit">Lithuanian (Lietuviskai)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_hpLangTitleID" href="Language.aspx?LangID=lob">Lobiri</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblSourceID">United Nations Operation in Cote d'Ivoire</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_hpLangTitleID" href="Language.aspx?LangID=ige">Low German (Niederdeutsche)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblSourceID">Institute for Low German</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_hpLangTitleID" href="Language.aspx?LangID=lbm1">Lozi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_hpLangTitleID" href="Language.aspx?LangID=lub">Luba-Kasai (Tshiluba)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblSourceID">Bibliothèque Nationale du Congo, Democratic Republic of Congo</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_hpLangTitleID" href="Language.aspx?LangID=lap1">Luganda/Ganda</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblSourceID">NGO, Uganda</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_hpLangTitleID" href="Language.aspx?LangID=mlo1">Lunda/Chokwe-lunda</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_hpLangTitleID" href="Language.aspx?LangID=lue">Luvale</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_hpLangTitleID" href="Language.aspx?LangID=lux">Luxembourgish (Lëtzebuergeusch)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblSourceID">Ministère de l'Education, Luxembourg</span></td>
+          </tr>
+      </td>
+	</tr>
+	<tr>
+		<th scope="col" class="UDHRHeader">
+            <tr>
+                <th style="width:15%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID1">Translation</span>   </th>
+                <!-- th style="width:20%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID2">Region</span>   </!-->
+                <th style="width:55%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID3">Translation Source</span></th>
+          </tr>
+     </th>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_hpLangTitleID" href="Language.aspx?LangID=mkj">Macedonian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblSourceID">Macedonian Board, Skopje</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_hpLangTitleID" href="Language.aspx?LangID=mhj">Madurese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_hpLangTitleID" href="Language.aspx?LangID=mqm">Magahi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblSourceID">United Nations Information Centre, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_hpLangTitleID" href="Language.aspx?LangID=mag">Magar (Dhut)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblSourceID">Nepal Magar Association</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_hpLangTitleID" href="Language.aspx?LangID=hng">Magyar (Hungarian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_hpLangTitleID" href="Language.aspx?LangID=mai">Maithili</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_hpLangTitleID" href="Language.aspx?LangID=mjz">Majhi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblSourceID">Nepal Majhi Utthan Sangha</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_hpLangTitleID" href="Language.aspx?LangID=kde">Makonde</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblSourceID">United Nations Development Programme, Tanzania</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_hpLangTitleID" href="Language.aspx?LangID=vmw">Makua (Mozambique)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_hpLangTitleID" href="Language.aspx?LangID=mex">Malagasy</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblSourceID">United Nations Information Centre, Madagascar</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_hpLangTitleID" href="Language.aspx?LangID=mli">Malay (Bahasa Melayu)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_hpLangTitleID" href="Language.aspx?LangID=mjs">Malayalam</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_hpLangTitleID" href="Language.aspx?LangID=div">Maldivian (Dhivehi)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblSourceID">Human Rights Commission of the Maldives, Maldives</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_hpLangTitleID" href="Language.aspx?LangID=mls">Maltese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblSourceID">Maltese University, Malta</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_hpLangTitleID" href="Language.aspx?LangID=mam">Mam</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblSourceID">Instituto de Linguistica, Argentina</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_hpLangTitleID" href="Language.aspx?LangID=mni">Maninka</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblSourceID">Ministère de l'Education Nationale, Guinea</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_hpLangTitleID" href="Language.aspx?LangID=bpy">Manipuri</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_hpLangTitleID" href="Language.aspx?LangID=mbf">Maori</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblSourceID">New Zealand Human Rights Commission, New Zealand</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_hpLangTitleID" href="Language.aspx?LangID=rrt">Maori (Cook Islands) (Rarotongan)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblSourceID">Ministry of Foreign Affairs and Immigration, Cook Islands</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_hpLangTitleID" href="Language.aspx?LangID=aru">Mapudungun (Mapuzgun)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblSourceID">United Nations Information Centre, Argentina/Uruguay</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_hpLangTitleID" href="Language.aspx?LangID=mrt">Marathi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_hpLangTitleID" href="Language.aspx?LangID=mzm">Marshallese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_hpLangTitleID" href="Language.aspx?LangID=mkd">Marwari</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_hpLangTitleID" href="Language.aspx?LangID=mcf">Matsés</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_hpLangTitleID" href="Language.aspx?LangID=yua">Mayan (Yucateco)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblSourceID">United Nations Information Centre, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_hpLangTitleID" href="Language.aspx?LangID=maz">Mazahua (Jñatrjo)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblSourceID">United Nations Department of Public Information, NY, in cooperation with the Ministry of Education, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_hpLangTitleID" href="Language.aspx?LangID=mao">Mazateco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblSourceID">United Nations Department of Public Information, NY, in cooperation with the Ministry of Education, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_hpLangTitleID" href="Language.aspx?LangID=mlo">Mbundu (Kimbundu)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Angola</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_hpLangTitleID" href="Language.aspx?LangID=mfy">Mende</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblSourceID">National Commission for Democracy and Human Rights, Sierra Leone</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_hpLangTitleID" href="Language.aspx?LangID=mic">Mikmaq/Micmac</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblSourceID">Permanent Mission of Canada to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_hpLangTitleID" href="Language.aspx?LangID=mpu">Minangkabau</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblSourceID">United Nations Information Centre, Indonesia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_hpLangTitleID" href="Language.aspx?LangID=miq">Miskito</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblSourceID">Comité para la Defensa de los Derechos Humanos, Honduras</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_hpLangTitleID" href="Language.aspx?LangID=mto">Mixe</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblSourceID">VIDES International</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_hpLangTitleID" href="Language.aspx?LangID=mxv">Mixteco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblSourceID">United Nations Information Centre, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_hpLangTitleID" href="Language.aspx?LangID=lus">Mizo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_hpLangTitleID" href="Language.aspx?LangID=khk">Mongolian (Khalkha)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblSourceID">CHR Technical Cooperation Branch, Mongolia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_hpLangTitleID" href="Language.aspx?LangID=mhm">Mooré/More</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblSourceID">National Commission for UNESCO, Burkina-Faso</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_hpLangTitleID" href="Language.aspx?LangID=moz">Mozarabic (Ajami)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblSourceID"></span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_hpLangTitleID" href="Language.aspx?LangID=unr">Mundari</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_hpLangTitleID" href="Language.aspx?LangID=1111">Ñahñú (Otomí)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblSourceID">Casa del Escritor Indigena, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_hpLangTitleID" href="Language.aspx?LangID=nhn">Nahuatl</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblSourceID">United Nations Information Centre, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_hpLangTitleID" href="Language.aspx?LangID=gld">Nanai</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_hpLangTitleID" href="Language.aspx?LangID=nav">Navaho (Dine, Navajo)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblSourceID">Navajo Interpreting Services, US</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_hpLangTitleID" href="Language.aspx?LangID=nel">Ndebele</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblSourceID">United Nations Information Centre, Zimbabwe</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_hpLangTitleID" href="Language.aspx?LangID=dut">Nederlands (Dutch)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_hpLangTitleID" href="Language.aspx?LangID=yrk">Nenets</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_hpLangTitleID" href="Language.aspx?LangID=nep">Nepali</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_hpLangTitleID" href="Language.aspx?LangID=new">Newar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblSourceID">Newa: Dey Daboo</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_hpLangTitleID" href="Language.aspx?LangID=nio">Nganasan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_hpLangTitleID" href="Language.aspx?LangID=nba">Ngangela (Nyemba)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Angola</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_hpLangTitleID" href="Language.aspx?LangID=ige">Niederdeutsche (Low German)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblSourceID">Institute for Low German</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_hpLangTitleID" href="Language.aspx?LangID=pcm">Nigerian Pidgin English</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblSourceID">United Nations Information Centre, Nigeria</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_hpLangTitleID" href="Language.aspx?LangID=jpn">Nihongo (Japanese)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblSourceID">United Nations Information Centre, Japan, and the Ministry of Justice and Human Rights NGOs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_hpLangTitleID" href="Language.aspx?LangID=Nivkh">Nivkh</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_hpLangTitleID" href="Language.aspx?LangID=not">Nomatsiguenga</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_hpLangTitleID" href="Language.aspx?LangID=srt">Northern Sotho/Pedi/Sepedi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with UNESCO</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_hpLangTitleID" href="Language.aspx?LangID=nrr">Norwegian (Bokmål) (Norsk, Bokmål)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_hpLangTitleID" href="Language.aspx?LangID=nrn">Norwegian (Nynorsk) (Norsk, Nynorsk)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_hpLangTitleID" href="Language.aspx?LangID=nus">Nuer</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblSourceID">United Nations Mission In Sudan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_hpLangTitleID" href="Language.aspx?LangID=nyz">Nyamwezi (Kinyamwezi)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblSourceID">United Nations Development Programme, Tanzania</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_hpLangTitleID" href="Language.aspx?LangID=nyj1">Nyanja (Chechewa)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_hpLangTitleID" href="Language.aspx?LangID=nyj">Nyanja/Chinyanja</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_hpLangTitleID" href="Language.aspx?LangID=nze">Nzema</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblSourceID">United Nations Department of Public Information, NY, jointly with Bureau des langues du Ghana and Association of Negro Business and Professional Women's Clubs</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_hpLangTitleID" href="Language.aspx?LangID=auv1">Occitan Auvergnat</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_hpLangTitleID" href="Language.aspx?LangID=prv1">Occitan Languedocien</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_hpLangTitleID" href="Language.aspx?LangID=oki">Ogiek</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblSourceID">Peter Kiplangat Cheruiyot, Former OHCHR Fellow</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_hpLangTitleID" href="Language.aspx?LangID=ojb">Ojibway (Ojibwe)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblSourceID">Permanent Mission of Canada to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_hpLangTitleID" href="Language.aspx?LangID=ory">Oriya</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_hpLangTitleID" href="Language.aspx?LangID=gax">Oromiffa (Afaan Oromo)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblSourceID">Dema Translation and Editing Service</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_hpLangTitleID" href="Language.aspx?LangID=ose">Osetin (Ossetian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblSourceID">Kazbek T Boutaev, (University of Pennsylvania, Philadelphia, US)</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_hpLangTitleID" href="Language.aspx?LangID=1114">Oshiwambo (Ndonga)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblSourceID">United Nations Information Centre, Namibia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_hpLangTitleID" href="Language.aspx?LangID=1111">Otomí (Ñahñú)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblSourceID">Casa del Escritor Indigena, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_hpLangTitleID" href="Language.aspx?LangID=lot">Otuho</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblSourceID">United Nations Mission In Sudan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_hpLangTitleID" href="Language.aspx?LangID=pbb">Paez</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblSourceID">Centro Colombiano de Estudios de Lenguas Aborígenes from the University of Los Andes, Colombia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_hpLangTitleID" href="Language.aspx?LangID=1123">Pai Koka</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_hpLangTitleID" href="Language.aspx?LangID=plu">Palauan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_hpLangTitleID" href="Language.aspx?LangID=pap">Papiamentu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_lblSourceID">Ramon Todd, Former OHCHR Fellow</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_hpLangTitleID" href="Language.aspx?LangID=pbu">Pashto/Pakhto</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_lblSourceID">United Nations Development Programme, Pakistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_hpLangTitleID" href="Language.aspx?LangID=prs">Persian/Farsi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_lblRegionID">Middle East</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_lblSourceID">United Nations Information Centre, Iran</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_hpLangTitleID" href="Language.aspx?LangID=fum">Peuhl</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_lblSourceID">Ministère de l'Education Nationale, Guinea</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_hpLangTitleID" href="Language.aspx?LangID=frn2">Picard</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_lblSourceID">Diffusion Multilingue des Droits de l'Homme, Belgium</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_hpLangTitleID" href="Language.aspx?LangID=pis">Pijin (Solomons Pidgin)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_lblSourceID">United Nations Development Programme, Solomons Islands</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_hpLangTitleID" href="Language.aspx?LangID=ppl">Pipil</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_lblSourceID">Office of the High Commissioner for Human Rights and the Government of El Salvador</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_hpLangTitleID" href="Language.aspx?LangID=pql">Polish (Polski)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_hpLangTitleID" href="Language.aspx?LangID=pnf">Ponapean</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_hpLangTitleID" href="Language.aspx?LangID=por">Portuguese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_lblSourceID">United Nations Information Centre, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_hpLangTitleID" href="Language.aspx?LangID=pro">Prouvençau</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_lblSourceID">Prof. Philippe Blanchet. Université de Rennes, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_hpLangTitleID" href="Language.aspx?LangID=fum1">Pulaar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_lblSourceID">United Nations Information Centre, Senegal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_hpLangTitleID" href="Language.aspx?LangID=fuf">Pular</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_lblSourceID">Ministère de l'Education Nationale, Guinea</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_hpLangTitleID" href="Language.aspx?LangID=pnj1">Punjabi/Panjabi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_hpLangTitleID" href="Language.aspx?LangID=1112">Purhépecha</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_lblSourceID">United Nations Department of Public Information, Mexico, in cooperation with the Casa del Escritor Indigena</span></td>
+          </tr>
+      </td>
+	</tr>
+	<tr>
+		<th scope="col" class="UDHRHeader">
+            <tr>
+                <th style="width:15%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID1">Translation</span>   </th>
+                <!-- th style="width:20%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID2">Region</span>   </!-->
+                <th style="width:55%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID3">Translation Source</span></th>
+          </tr>
+     </th>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_hpLangTitleID" href="Language.aspx?LangID=1116">Q'echi/Kekchi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblSourceID">Instituto de Linguistica, Argentina</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_hpLangTitleID" href="Language.aspx?LangID=qec1">Quechua</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblSourceID">United Nations Information Centre, Bolivia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_hpLangTitleID" href="Language.aspx?LangID=qeg">Quechua de Ambo-Pasco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_hpLangTitleID" href="Language.aspx?LangID=quy">Quechua de Ayacucho</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_hpLangTitleID" href="Language.aspx?LangID=qnt">Quechua de Cajamarca</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_hpLangTitleID" href="Language.aspx?LangID=qar">Quechua de Cotahuasi (Arequipa)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_hpLangTitleID" href="Language.aspx?LangID=qej">Quechua de Huamalies (Huanuco)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_hpLangTitleID" href="Language.aspx?LangID=qei">Quechua de Margos (Sur de Dios de Mayo, Huanuco)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_hpLangTitleID" href="Language.aspx?LangID=qed">Quechua de Pomabamba (Ancash)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_hpLangTitleID" href="Language.aspx?LangID=qan">Quechua del Callejon de Huaylas</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_hpLangTitleID" href="Language.aspx?LangID=quz">Quechua del Cusco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_hpLangTitleID" href="Language.aspx?LangID=qju">Quechua del Norte de Junin</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_hpLangTitleID" href="Language.aspx?LangID=qud1">Quichua</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblSourceID">Sociedad Ecuatoriana Para Los Derechos Humanos, Instituto de Derechos Humanos-Universidad Central del Ecuador, Fundacion Friedrich Naumann</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_hpLangTitleID" href="Language.aspx?LangID=raj">Rajasthani</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_hpLangTitleID" href="Language.aspx?LangID=rjs">Rajbansi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblSourceID">Rajbansi Society Development</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_hpLangTitleID" href="Language.aspx?LangID=rrt">Rarotongan (Maori (Cook Islands))</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblSourceID">Ministry of Foreign Affairs and Immigration, Cook Islands</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_hpLangTitleID" href="Language.aspx?LangID=rhe">Rhaeto-Romance (Rumantsch)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblSourceID">NGO, Switzerland</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_hpLangTitleID" href="Language.aspx?LangID=rmn1">Romani</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with Institut National des Langues et Civilisations Orientales</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_hpLangTitleID" href="Language.aspx?LangID=rum">Romanian (Româna)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_hpLangTitleID" href="Language.aspx?LangID=koo1">Rukonzo (Konjo)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblSourceID">NGO, Uganda</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_hpLangTitleID" href="Language.aspx?LangID=rud1">Rundi/Kirundi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblSourceID">Ligue burundaise des droits de l'homme, Burundi</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_hpLangTitleID" href="Language.aspx?LangID=nyn1">Runyankore-rukiga/Nkore-kiga</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblSourceID">NGO, Uganda</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_hpLangTitleID" href="Language.aspx?LangID=rus">Russian (Russky)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl23_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_hpLangTitleID" href="Language.aspx?LangID=lpi">Sami/Lappish</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl24_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_hpLangTitleID" href="Language.aspx?LangID=eml">Sammarinese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl25_lblSourceID">C. Guidi, Biblioteca Popolare di Serravalle, San Marino</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_hpLangTitleID" href="Language.aspx?LangID=smy">Samoan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl26_lblSourceID">United Nations Development Programme, Samoa</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_hpLangTitleID" href="Language.aspx?LangID=saj">Sango (Sangho)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl27_lblSourceID">United Nations Development Programme, Central African Republic</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_hpLangTitleID" href="Language.aspx?LangID=skt">Sanskrit</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl28_lblSourceID">United Nations Information Centre, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_hpLangTitleID" href="Language.aspx?LangID=sat">Santhali</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl29_lblSourceID">People’s Watch, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_hpLangTitleID" href="Language.aspx?LangID=1124">Sapara Atupama</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl30_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_hpLangTitleID" href="Language.aspx?LangID=skr">Saraiki</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl31_lblSourceID">Actaf Hussain</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_hpLangTitleID" href="Language.aspx?LangID=srd">Sardinian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl32_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_hpLangTitleID" href="Language.aspx?LangID=hns">Sarnámi Hindustani</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl33_lblSourceID">Deep Mahangi, Former OHCHR Fellow</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_hpLangTitleID" href="Language.aspx?LangID=sco">Scots</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl34_lblSourceID">Amnesty International, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_hpLangTitleID" href="Language.aspx?LangID=gls">Scottish Gaelic</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl35_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_hpLangTitleID" href="Language.aspx?LangID=ses">Seereer</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl36_lblSourceID">United Nations Information Centre, Senegal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_hpLangTitleID" href="Language.aspx?LangID=src5">Serbian (Cyrillic) (Srpski)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl37_lblSourceID">Permanent Mission of the Federal Republic of Yugoslavia to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_hpLangTitleID" href="Language.aspx?LangID=src3">Serbian (Latin) (Srpski)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl38_lblSourceID">Permanent Mission of the Federal Republic of Yugoslavia to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_hpLangTitleID" href="Language.aspx?LangID=crs">Seselwa Creole French</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl39_lblSourceID"></span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_hpLangTitleID" href="Language.aspx?LangID=sjn">Shan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl40_lblSourceID">United Nations Information Centre, Burma</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_hpLangTitleID" href="Language.aspx?LangID=mcd">Sharanahua</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl41_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_hpLangTitleID" href="Language.aspx?LangID=xsr">Sherpa</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl42_lblSourceID">Nepal Sherpa Association</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_hpLangTitleID" href="Language.aspx?LangID=shk">Shilluk</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl43_lblSourceID">United Nations Mission In Sudan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_hpLangTitleID" href="Language.aspx?LangID=swb">Shimaore</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl44_lblSourceID">Service linguistique du Conseil Général de Mayotte</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_hpLangTitleID" href="Language.aspx?LangID=shp">Shipibo-Conibo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl45_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_hpLangTitleID" href="Language.aspx?LangID=shd">Shona</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl46_lblSourceID">United Nations Information Centre, Zimbabwe</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_hpLangTitleID" href="Language.aspx?LangID=cjs">Shor</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl47_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_hpLangTitleID" href="Language.aspx?LangID=aln">Shqip (Albanian)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl48_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_hpLangTitleID" href="Language.aspx?LangID=1125">Shuar Chicham</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl49_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_hpLangTitleID" href="Language.aspx?LangID=1126">Sia Pedee</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl50_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_hpLangTitleID" href="Language.aspx?LangID=snd">Sindhi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl51_lblSourceID">United Nations Information Centre, India</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_hpLangTitleID" href="Language.aspx?LangID=snh">Sinhala</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl52_lblSourceID">Human Rights Centre of the Sri Lanka Foundation, Sri Lanka</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_hpLangTitleID" href="Language.aspx?LangID=swz1">Siswati</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl53_lblSourceID">United Nations Information Centre, Swaziland</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_hpLangTitleID" href="Language.aspx?LangID=slo">Slovak (Slovencina)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl54_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_hpLangTitleID" href="Language.aspx?LangID=slv">Slovenian (Slovenscina)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl55_lblSourceID">Permanent Mission of the Republic of Slovenia to the United Nations in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_hpLangTitleID" href="Language.aspx?LangID=pis">Solomons Pidgin (Pijin)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl56_lblSourceID">United Nations Development Programme, Solomons Islands</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_hpLangTitleID" href="Language.aspx?LangID=som">Somali</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl57_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with l'Agence de Coopération Culturelle et Technique</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_hpLangTitleID" href="Language.aspx?LangID=snn">Soninké (Soninkanxaane)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl58_lblSourceID">Tostan, Senegal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_hpLangTitleID" href="Language.aspx?LangID=wee">Sorbian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl59_lblSourceID">Permanent Mission of Germany to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_hpLangTitleID" href="Language.aspx?LangID=sso">Southern Sotho/Sotho/Sesotho/Sutu/Sesutu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl60_lblSourceID">Diffusion Multilingue des Droits de l'Homme, South Africa</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_hpLangTitleID" href="Language.aspx?LangID=spn">Spanish (Español)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl61_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_hpLangTitleID" href="Language.aspx?LangID=sua">Sukuma</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl62_lblSourceID">United Nations Development Programme, Tanzania</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_hpLangTitleID" href="Language.aspx?LangID=suo">Sundanese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl63_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_hpLangTitleID" href="Language.aspx?LangID=fin">Suomi (Finnish)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl64_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_hpLangTitleID" href="Language.aspx?LangID=sus">Sussu/Soussou/Sosso/Soso/Susu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl65_lblSourceID">Ministère de l'Education Nationale, Guinea</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_hpLangTitleID" href="Language.aspx?LangID=swa">Swahili/Kiswahili</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl66_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_hpLangTitleID" href="Language.aspx?LangID=crm">Swampy Cree</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl67_lblSourceID">Permanent Mission of Canada to the United Nations Office in Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_hpLangTitleID" href="Language.aspx?LangID=swd">Swedish (Svenska)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl68_lblSourceID">United Nations Information Centre, Denmark</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_hpLangTitleID" href="Language.aspx?LangID=tht">Tahitian</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl69_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_hpLangTitleID" href="Language.aspx?LangID=pet">Tajik</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl70_lblSourceID">The Presidential Apparatus of the Republic of Tajikistan, Tajikistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_hpLangTitleID" href="Language.aspx?LangID=Ta1">Tajpuriya</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl71_lblSourceID">Tajpuriya Society Welfare Council</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_hpLangTitleID" href="Language.aspx?LangID=tly">Talysh</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl72_lblSourceID">Human Rights Center of Azerbaijan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_hpLangTitleID" href="Language.aspx?LangID=taj">Tamang (Tam)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl73_lblSourceID">Nepal Tamang Ghedung, Nepal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_hpLangTitleID" href="Language.aspx?LangID=taq">Tamasheq</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl74_lblSourceID">Association Tagazt</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_hpLangTitleID" href="Language.aspx?LangID=tzm">Tamazight (Beraber)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl75_lblSourceID">Observatoire National de Droits de l'Homme, Algeria</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_hpLangTitleID" href="Language.aspx?LangID=tcv">Tamil</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl76_lblSourceID">Human Rights Centre of the Sri Lanka Foundation, Sri Lanka</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_hpLangTitleID" href="Language.aspx?LangID=ttr">Tatar</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl77_lblSourceID">The Committee for the Protection of Human Rights, Republic of Tatarstan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_hpLangTitleID" href="Language.aspx?LangID=cjk">Tchocwe (Angola)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl78_lblSourceID">Procuradoria-Geral da Republica, Portugal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_hpLangTitleID" href="Language.aspx?LangID=tcw">Telugu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl79_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_hpLangTitleID" href="Language.aspx?LangID=1118">Tének (Huasteco)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl80_lblSourceID">United Nations Department of Public Information, NY, in cooperation with the Ministry of Education, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_hpLangTitleID" href="Language.aspx?LangID=ttm">Tetum</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl81_lblSourceID">On-Call Interpreters and Translators Agency, Australia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_hpLangTitleID" href="Language.aspx?LangID=thj">Thai</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl82_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_hpLangTitleID" href="Language.aspx?LangID=ths">Thakali</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl83_lblSourceID">Thakali Sewa Samittee</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_hpLangTitleID" href="Language.aspx?LangID=thf">Thangmi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl84_lblSourceID">Nepal Thangmi Society</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_hpLangTitleID" href="Language.aspx?LangID=thl">Tharu-Dangaura</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl85_lblSourceID">Tharu Kalyankari Sabha</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_hpLangTitleID" href="Language.aspx?LangID=tej">Themne (Temne)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl86_lblSourceID">National Commission for Democracy and Human Rights, Sierra Leone</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_hpLangTitleID" href="Language.aspx?LangID=tic">Tibetan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl87_lblSourceID">Office of the Representative of the H.H. the Dalai Lama, Tibet</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_hpLangTitleID" href="Language.aspx?LangID=tca">Ticuna</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl88_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_hpLangTitleID" href="Language.aspx?LangID=tgn">Tigrinya (Tigrigna)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl89_lblSourceID">Dema Translation and Editing Service</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_hpLangTitleID" href="Language.aspx?LangID=tiv">Tiv</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl90_lblSourceID">United Nations Information Centre, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_hpLangTitleID" href="Language.aspx?LangID=tob">Toba</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl91_lblSourceID">United Nations Information Centre, Argentina/Uruguay</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl92_hpLangTitleID" href="Language.aspx?LangID=toj">Tojol-a'b'al</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl92_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl92_lblSourceID">United Nations Information Centre, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl93_hpLangTitleID" href="Language.aspx?LangID=pdg">Tok Pisin</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl93_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl93_lblSourceID">Baua Baua Popular, Papua New Guinea</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl94_hpLangTitleID" href="Language.aspx?LangID=toi">Tonga</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl94_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl94_lblSourceID">United Nations Information Centre, Zambia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl95_hpLangTitleID" href="Language.aspx?LangID=tov">Tongan (Tonga)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl95_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl95_lblSourceID">Tongan Human Rights and Democracy Movement, Tonga</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl96_hpLangTitleID" href="Language.aspx?LangID=top">Totonaco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl96_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl96_lblSourceID">United Nations Department of Public Information, NY, in cooperation with the Ministry of Education, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl97_hpLangTitleID" href="Language.aspx?LangID=tru1">Trukese (Chuuk)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl97_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl97_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl98_hpLangTitleID" href="Language.aspx?LangID=cof">Tsafiki</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl98_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl98_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl99_hpLangTitleID" href="Language.aspx?LangID=lub">Tshiluba (Luba-Kasai)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl99_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl99_lblSourceID">Bibliothèque Nationale du Congo, Congo</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl100_hpLangTitleID" href="Language.aspx?LangID=tsh">Tshivenda</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl100_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl100_lblSourceID">University of Cape Town, Faculty of Law, South Africa</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl101_hpLangTitleID" href="Language.aspx?LangID=trk">Turkish (Türkçe)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl101_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl101_lblSourceID">Secretariat of the Human Rights Coordinating Committee, Turkey</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl102_hpLangTitleID" href="Language.aspx?LangID=tck">Turkmen</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl102_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl102_lblSourceID">National Commission for UNESCO, Turkeminstan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl103_hpLangTitleID" href="Language.aspx?LangID=tyv">Tuvan</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl103_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl103_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl104_hpLangTitleID" href="Language.aspx?LangID=tzc1">Tzeltal</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl104_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl104_lblSourceID">United Nations Information Centre, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl105_hpLangTitleID" href="Language.aspx?LangID=tzc">Tzotzil</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl105_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl105_lblSourceID">United Nations Information Centre, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl106_hpLangTitleID" href="Language.aspx?LangID=uig">Uighur</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl106_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl106_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl107_hpLangTitleID" href="Language.aspx?LangID=oaa">Uilta</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl107_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl107_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl108_hpLangTitleID" href="Language.aspx?LangID=ukr">Ukrainian (Ukrayins'ka)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl108_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl108_lblSourceID">Ukrainian Union of Jurists, Ukraine</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl109_hpLangTitleID" href="Language.aspx?LangID=mnf">Umbundu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl109_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl109_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Angola</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl110_hpLangTitleID" href="Language.aspx?LangID=kxl">Uranw-Jhangad</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl110_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl110_lblSourceID">Nepal Jhangad (Uranw) Kodrem Sudhar Karya Guthiyar Aa Karyan Sudhar Samittee</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl111_hpLangTitleID" href="Language.aspx?LangID=ura">Urarina</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl111_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl111_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl112_hpLangTitleID" href="Language.aspx?LangID=urd">Urdu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl112_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl112_lblSourceID">United Nations Information Centre, Pakistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl113_hpLangTitleID" href="Language.aspx?LangID=uzb1">Uzbek (Cyrillic)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl113_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl113_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Uzbekistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl114_hpLangTitleID" href="Language.aspx?LangID=uzb">Uzbek (Latin)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl114_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl114_lblSourceID">United Nations Educational, Scientific and Cultural Organization, Uzbekistan</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl115_hpLangTitleID" href="Language.aspx?LangID=vai">Vai</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl115_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl115_lblSourceID">Sterling Memorial Library in Yale University</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl116_hpLangTitleID" href="Language.aspx?LangID=vep">Veps</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl116_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl116_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl117_hpLangTitleID" href="Language.aspx?LangID=vie">Vietnamese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl117_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl117_lblSourceID">United Nations Development Programme, Viet Nam</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl118_hpLangTitleID" href="Language.aspx?LangID=rmy1">Vlach</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl118_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl118_lblSourceID">UN Department for General Assembly and Conference Management German Translation Service, NY</span></td>
+          </tr>
+      </td>
+	</tr>
+	<tr>
+		<th scope="col" class="UDHRHeader">
+            <tr>
+                <th style="width:15%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID1">Translation</span>   </th>
+                <!-- th style="width:20%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID2">Region</span>   </!-->
+                <th style="width:55%; text-align:left"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl00_lblID3">Translation Source</span></th>
+          </tr>
+     </th>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_hpLangTitleID" href="Language.aspx?LangID=frn1">Walloon/Wallon</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl01_lblSourceID">Waremme - Ville de la Paix, Wallonie, Belgique</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_hpLangTitleID" href="Language.aspx?LangID=ako">Wama</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl02_lblSourceID">Commission béninoise des Droits de l'Homme, Benin</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_hpLangTitleID" href="Language.aspx?LangID=1127">Wao Tededo</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl03_lblSourceID">Office of the High Commissioner for Human Rights - Ecuador Field Office</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_hpLangTitleID" href="Language.aspx?LangID=wry">Waray</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl04_lblSourceID">Komisyon ng Karapatang Pantao, The Philippines</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_hpLangTitleID" href="Language.aspx?LangID=guc">Wayuu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl05_lblSourceID">Centro Colombiano de Estudios de Lenguas Aborígenes from the University of Los Andes, Colombia</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_hpLangTitleID" href="Language.aspx?LangID=wls">Welsh (Cymraeg)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl06_lblSourceID">United Nations Association Wales, UK</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_hpLangTitleID" href="Language.aspx?LangID=tsw">Western Sotho/Tswana/Setswana</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl07_lblSourceID">Diffusion Multilingue des Droits de l'Homme, South Africa</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_hpLangTitleID" href="Language.aspx?LangID=wol">Wolof</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl08_lblSourceID">United Nations Information Centre, Senegal</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_hpLangTitleID" href="Language.aspx?LangID=xos">Xhosa</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl09_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with UNESCO</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_hpLangTitleID" href="Language.aspx?LangID=yad">Yagua</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl10_lblSourceID">Coordinadora Nacional de Derechos Humanos, Peru</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_hpLangTitleID" href="Language.aspx?LangID=sah">Yakut</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl11_lblSourceID">Office of the High Commissioner for Human Rights - Russian Federation</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_hpLangTitleID" href="Language.aspx?LangID=guu">Yanomamö</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblRegionID">Central and South America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl12_lblSourceID">International Institute of Mary Our Help of the Salesians of Don Bosco</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_hpLangTitleID" href="Language.aspx?LangID=yao">Yao</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl13_lblSourceID">United Nations Office of the High Comissioner for Human Rights, Geneva</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_hpLangTitleID" href="Language.aspx?LangID=yps">Yapese</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl14_lblSourceID">United Nations Department of Public Information, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_hpLangTitleID" href="Language.aspx?LangID=iii">Yi</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl15_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_hpLangTitleID" href="Language.aspx?LangID=ydd">Yiddish</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl16_lblSourceID">Raphael Finkel and Sholem Berger, University of Kentucky, USA</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_hpLangTitleID" href="Language.aspx?LangID=yor">Yoruba (Yorùbá)</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl17_lblSourceID">Diffusion Multilingue des Droits de l'Homme, France, in cooperation with l'Agence de Coopération Culturelle et Technique</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_hpLangTitleID" href="Language.aspx?LangID=ykg">Yukagir</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblRegionID">Europe</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl18_lblSourceID">L'Auravetl'an Foundation, NY</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_hpLangTitleID" href="Language.aspx?LangID=zam">Zapoteco</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl19_lblSourceID">United Nations Department of Public Information, NY, in cooperation with the Ministry of Education, Mexico</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_hpLangTitleID" href="Language.aspx?LangID=ztu1">Zapoteco, San Lucas Quiaviní</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblRegionID">North America</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl20_lblSourceID">Felipe H. Lopez and Pamela Munro (University of California, Los Angeles, US)</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_hpLangTitleID" href="Language.aspx?LangID=ccx">Zhuang</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblRegionID">Asia and Pacific</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl21_lblSourceID">United Nations Development Programme, China</span></td>
+          </tr>
+      </td>
+	</tr><tr>
+		<td class="UDHRItem">
+          <tr>
+             <td style="width:15%" > <a id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_hpLangTitleID" href="Language.aspx?LangID=zuu">Zulu</a></td>
+             <!-- td style="width:20%" ><span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblRegionID">Africa</span></!-->
+             <td style="width:55%"> <span id="ctl00_PlaceHolderMain_usrUDHRSearchByLangID_dataListbyLangID_ctl22_lblSourceID">Community Law Centre, South Africa</span></td>
+          </tr>
+      </td>
+	</tr>
+
+</table>
+</body>
+</html>


### PR DESCRIPTION
This code manages samples based on article 1 of the universal declaration of human rights.  We have been using  some translations obtained by hand, this bases the samples on data obtained from unicode.org/udhr and attribution data from ohchr.org and uses tooling to put it together.

It's not guaranteed that the new sample data is better than the old-- I've noticed and fixed some typos-- but this lets us base our versions on a known source.

The attribution data is used for notices ohchr/un have requested we show when using these translations.  Unfortunately different translations require different notices.