### PR TITLE
Remove redundant '?' in regex.

### DIFF
--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -248,7 +248,7 @@ class FontCondition(object):
       value = re.compile(value)
     self.__dict__[condition_name] = (fn, value)
 
-  line_re = re.compile(r'([^ \t]+)\s+([^ \t]+)(.*)?')
+  line_re = re.compile(r'([^ \t]+)\s+([^ \t]+)(.*)')
   def modify_line(self, line):
     line = line.strip()
     m = self.line_re.match(line)


### PR DESCRIPTION
Python versions before 2.7.6 complain about '(.*)?' since
the '?' is redundant.  Regex compilation should strip this, but didn't
before then, and reported 'sre_constants.error: nothing to repeat'.
Clients should use more recent versions of the python 2.7 stream as
there might be more issues than this one; I fixed this mostly as reference.