### PR TITLE
Check for bad name ids in feature lists using FeatureParamsStylisticSet.

### DIFF
--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -372,8 +372,10 @@ class TestSpec(object):
   complex -- gpos and gsub tests
     gpos
       missing
+      ui_name_id -- FeatureParamsStylisticSet.UINameID not in name table
     gsub
       missing
+      ui_name_id -- FeatureParamsStylisticSet.UINameID not in name table
   bidi -- tests bidi pairs, properties
     rtlm_non_mirrored -- rtlm GSUB feature applied to private-use or non-mirrored character
     ompl_rtlm -- rtlm GSUB feature applied to ompl char


### PR DESCRIPTION
This is in response to nototools issue #61.

Adds new test tags complex/gpos/ui_name_id and
complex/gsub/ui_name_id, which control a test that scans the GSUB/GPOS
feature list for features using FeatureParamsStylisticSet that have a
UINameID that is not in the font's name table.

The bug described in the issue is no longer present in the font.  I
doctored a font to introduce the feature in the bug report (twice, one
with a bad name id, one with a good one) and used that to test this.