### PR TITLE
Clean up lint of cjk

### DIFF
--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -602,13 +602,12 @@ def check_font(font_props, filename_error,
             name += ' ' + font_props.subset
         else:
             cjk_script_to_name = {
-                'Jpan': ' JP',
-                'Kore': ' KR',
-                'Hans': ' SC',
-                'Hant': ' TC',
-                'CJK' : ' JP',  # TODO(dougfelt) fix to reflect fontNumber
+                'Jpan': 'JP',
+                'Kore': 'KR',
+                'Hans': 'SC',
+                'Hant': 'TC'
             }
-            name += ' CJK' + cjk_script_to_name[font_props.script]
+            name += ' CJK ' + cjk_script_to_name[font_props.script]
         name += ' ' + font_props.weight
         return name
 
@@ -654,8 +653,7 @@ def check_font(font_props, filename_error,
                 'Jpan': 'jp',
                 'Kore': 'kr',
                 'Hans': 'sc',
-                'Hant': 'tc',
-                'CJK': 'jp'  # TODO(dougfelt) fix to reflect fontNumber
+                'Hant': 'tc'
             }
             name += 'CJK' + cjk_script_to_name[font_props.script]
         name += '-' + font_props.weight


### PR DESCRIPTION
This splits out computation of the expected names for cjk/non-cjk into their own smaller methods, so that we can have one main method to check the name table rather than one for cjk and one for non-cjk, which was formerly the case.