### PR TITLE
Add a tool for generating text samples based on glyphs in a font.

### DIFF
--- a/nototools/noto_data.py
+++ b/nototools/noto_data.py
@@ -207,10 +207,7 @@ EXTRA_CHARACTERS_NEEDED = {
     'Zsym': [0x20BC, 0x20BD, 0x20BE],
 }
 
-
-CHARACTERS_NOT_NEEDED = {
-    'Arab': char_range(0x10E60, 0x10E7E),
-    'Latn': (  # Actually LGC
+LGC_CHARACTERS_NOT_NEEDED = frozenset(
         char_range(0x0370, 0x0373) +
         [0x0376, 0x0377, 0x03CF, 0x0951, 0x0952, 0x1E9C, 0x1E9D, 0x1E9F] +
         char_range(0x1EFA, 0x1EFF) +
@@ -227,7 +224,12 @@ CHARACTERS_NOT_NEEDED = {
         [0xA78D, 0xA78E, 0xA790, 0xA791] +
         char_range(0xA7A0, 0xA7A9) +
         char_range(0xA7FA, 0xA7FF) +
-        [0xA92E, 0xFB00, 0xFB05, 0xFB06]),
+        [0xA92E, 0xFB00, 0xFB05, 0xFB06])
+
+CHARACTERS_NOT_NEEDED = {
+    'Arab': char_range(0x10E60, 0x10E7E),
+    'Latn': LGC_CHARACTERS_NOT_NEEDED,
+    'LGC': LGC_CHARACTERS_NOT_NEEDED,
 }
 
 ACCEPTABLE_AS_COMBINING = {

--- a/nototools/sample_with_font.py
+++ b/nototools/sample_with_font.py
@@ -137,9 +137,9 @@ def _get_char_names(charset):
       except:
         name = None
       if not name or name == '<control>':
-        name = 'uni_%04x' % cp
+        name = '%04x' % cp
       else:
-        name = name.lower()
+        name = '%04x %s' % (cp, name.lower())
       name_map[name] = cp
 
   return name_map

--- a/nototools/sample_with_font.py
+++ b/nototools/sample_with_font.py
@@ -122,7 +122,7 @@ def _build_text(name_map, initial_text=''):
         continue
 
       text += unichr(name_map[matches[n]])
-      select_multiple = false
+      select_multiple = False
 
   print 'done.'
   return text

--- a/nototools/sample_with_font.py
+++ b/nototools/sample_with_font.py
@@ -111,7 +111,7 @@ def _build_text(name_map, initial_text=''):
         try:
           n = int(line)
           break
-        except:
+        except ValueError:
           continue
 
       if not select_multiple: # q

--- a/nototools/sample_with_font.py
+++ b/nototools/sample_with_font.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interactively generate sample text for a font.
+
+Often in bug reports people will describe text using character names.
+Replicating the sample text they describe can be a bit tedious.  This
+lets you interactively search characters in the font by name to assemble
+a string and save it to a file."""
+
+import argparse
+import codecs
+import readline
+
+from nototools import coverage
+from nototools import unicode_data
+
+from fontTools import ttLib
+
+def _build_text(name_map, initial_text=''):
+  text = initial_text
+  print 'build text using map of length %d' % len(name_map)
+  print ('enter \'quit\' to exit, '
+         '\'names\' for names, '
+         '\'dump\' to dump the current text, '
+         '\'clear\' to clear the current text, '
+         '\'write\' to be prompted for a filename to write the text to')
+  while True:
+    line = raw_input('> ')
+    if not line:
+      continue
+    if line == 'quit':
+      break
+    if line == 'names':
+      print 'names:\n  ' + '\n  '.join(sorted(name_map.keys()))
+      continue
+    if line == 'dump':
+      print 'dump: \'%s\'' % text
+      for cp in text:
+        print '%06x %s' % (ord(cp), unicode_data.name(cp))
+      continue
+    if line == 'clear':
+      text = ''
+      continue
+    if line == 'write':
+      line = raw_input('file name> ')
+      if line:
+        _write_text(line, text)
+      continue
+
+    matches = []
+    for name, cp in sorted(name_map.iteritems()):
+      if line in name:
+        matches.append(name)
+    if not matches:
+      print 'no match for "%s"'% line
+      continue
+    if len(matches) == 1:
+      print matches[0]
+      text += unichr(name_map[matches[0]])
+      continue
+
+    # if we match a full line, then use that
+    if line in matches:
+      print line
+      text += unichr(name_map[line])
+      continue
+
+    new_matches = []
+    for m in matches:
+      if line in m.split(' '):
+        new_matches.append(m)
+
+    if len(new_matches) == 1:
+      print new_matches[0]
+      text += unichr(name_map[new_matches[0]])
+      continue
+
+    if not new_matches:
+      new_matches = matches
+
+    while True:
+      print 'multiple matches:\n  ' + '\n  '.join(
+          '[%2d] %s' % (i, n) for i, n in enumerate(matches))
+      line = raw_input('0-%d or q > ' % (len(matches) - 1))
+      if line == 'q':
+        continue
+      try:
+        n = int(line)
+        if n < 0 or n >= len(matches):
+          print '%d out of range' % n
+          continue
+        text += unichr(name_map[matches[n]])
+        break
+      except:
+        continue
+
+  print 'done.'
+  return text
+
+
+def _get_char_names(charset):
+  name_map = {}
+  if charset:
+    for cp in charset:
+      name = unicode_data.name(cp)
+      name_map[name.lower()] = cp
+  return name_map
+
+
+def _write_text(filename, text):
+  with codecs.open(filename, 'w', 'utf-8') as f:
+    f.write(text)
+  print 'wrote %s' % filename
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-f', '--font',
+      help='font whose character map to restrict text to',
+      required=True)
+  parser.add_argument(
+      '-t', '--text',
+      help='initial text, prepend @ to read from file')
+
+  args = parser.parse_args()
+  if args.text:
+    if args.text[0] == '@':
+      with codecs.open(args.text[1:], 'r', 'utf-8') as f:
+        text = f.read()
+    else:
+      text = args.text
+  else:
+    text = ''
+
+  if args.font:
+    charset = coverage.character_set(args.font)
+    name_map = _get_char_names(charset)
+    text = _build_text(name_map, text)
+    print 'text: ' + text
+  else:
+    charset = None
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Some bug reports refer to names of characters in a particular script, but
don't provide the unicode values of these characters.  This tool lets
you interactively enter (portions of) names of characters and match these
names against the unicode names of characters available in the font to
build up a text string, which you can then write to a file.  This makes
it easier to build example text to view in that font.