### PR TITLE
Add variant selector lint tests.

### DIFF
--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -348,6 +348,7 @@ class TestSpec(object):
     private_use
     non_characters
     disallowed_ascii
+    variants
   head -- head table tests
     hhea
       ascent
@@ -400,6 +401,7 @@ class TestSpec(object):
     gsub
       missing
       ui_name_id -- FeatureParamsStylisticSet.UINameID not in name table
+      variants -- expect standard variants to be supported in gsub
   bidi -- tests bidi pairs, properties
     rtlm_non_mirrored -- rtlm GSUB feature applied to private-use or non-mirrored character
     ompl_rtlm -- rtlm GSUB feature applied to ompl char

--- a/nototools/lint_config.txt
+++ b/nototools/lint_config.txt
@@ -1,6 +1,9 @@
 # we've not checked this before
 disable head/os2/unicoderange
 
+# assume most variant support is based on cmap 14
+disable complex/gsub/variants
+
 vendor Monotype
 disable trademark # we can swat this ourselves
 disable vendor_url # we just changed this, and can swat it ourselves
@@ -35,15 +38,25 @@ enable cmap/script_required except cp 0487 a66f
 filename like Hanunoo
 enable gdef/classdef/combining_mismatch except cp 1734
 
+filename like Historic
+enable complex/gsub/variants
+disable cmap/variants
+
 filename like MeeteiMayek
 enable gdef/classdef/not_combining_mismatch except cp abe9-abea
 
 filename like Mongolian
 enable gdef/classdef/not_combining_mismatch except cp 180e
+enable complex/gsub/variants
+disable cmap/variants
 
 filename like Nastaliq
 # TODO: (dougfelt) find a better way of making these exceptions
 enable bounds/glyph/ymin except gid 222 223 250 280 882 887 950 959 974
+
+filename like PhagsPa
+enable complex/gsub/variants
+disable cmap/variants
 
 filename like Tamil
 enable script_required except cp 951-952 1cda a8f3
@@ -80,3 +93,7 @@ disable gdef/classdef/not_present
 # Adobe says that most of the glyphs are indeed reachable, so perhaps the linter/ttx is
 # at fault?
 disable reachable
+
+# Adobe has a well-defined list of variation sequences they support in the different CJK
+# fonts.  No point in trying to second-guess them.
+disable cmap/variants


### PR DESCRIPTION
This requires the hb-shape tool from Harfbuzz.  Python expects to be
able to call this tool using subprocess with the name 'hb-shape' when
running the GSUB-based tests.  So 'hb-shape' must be in a directory
on your PATH.

This does several things:
- adds functions to unicode_data.py that provide variant information
  on the non-emoji variants in StandardizedVariants.txt.  A previous
  submit handled only the emoji case.  Emoji variants are rather
  different from other variants, so it seemed reasonable to handle them
  separately.
- add lint tests to check that if a font contains characters that have
  standard variants, that it has a format 14 cmap and that the behavior
  corresponds to the behavior expected in the cmap (in particular, if
  a variant sequence corresponds to a CJK compatibility character, the
  character is in the cmap and the glyph for the sequence is the same as
  that for the character).
- add GSUB tests to check that the GSUB table will generate single glyphs
  for the standard variant sequences in the font.  This assumes the font
  generates single glyphs in this case, which is true for the two Noto
  fonts that currently do this, Mongolian and PhagsPa.  This uses
  harfbuzz to generate the glyphs.
- updates lint config to disable the GSUB based test by default, and
  enable it (and disable the cmap based test) for Mongolian, PhagsPa,
  and Historic.
- updates lint config to disable cmap tests for Adobe's CJK fonts. They
  carefully pick a subset of the standard variation sequences to support.