### PR TITLE
make unicoderange more accurate

### DIFF
--- a/nototools/autofix_for_release.py
+++ b/nototools/autofix_for_release.py
@@ -246,9 +246,11 @@ def fix_os2_unicoderange(font):
     os2_bitmap = font_data.get_os2_unicoderange_bitmap(font)
     expected_bitmap = font_data.get_cmap_unicoderange_bitmap(font)
     if os2_bitmap != expected_bitmap:
+        old_bitmap_string = font_data.unicoderange_bitmap_to_string(os2_bitmap)
         font_data.set_os2_unicoderange_bitmap(font, expected_bitmap)
         bitmap_string = font_data.unicoderange_bitmap_to_string(expected_bitmap)
-        print ('Set unicoderanges: ' + bitmap_string)
+        print 'Change unicoderanges from:\n  %s\nto:\n  %s' % (
+            old_bitmap_string, bitmap_string)
         return True
     return False
 

--- a/nototools/opentype_data.py
+++ b/nototools/opentype_data.py
@@ -293,7 +293,10 @@ def collect_unicoderange_info(cmap):
         while index < limit:
             tup = ur_data[index]
             if cp <= tup[1]:
-                range_count += 1
+                # the ranges are disjoint and some characters fall into no
+                # range, e.g. Javanese.
+                if cp >= tup[0]:
+                    range_count += 1
                 break
             if range_count:
                 result.append((range_count, ur_data[index]))


### PR DESCRIPTION
Two small related changes, prompted by running autofix on Javanese.
- autofix_for_release now reports both the old and new unicoderange info
  when it changes it.  Formerly it only reported the new info, so it
  was not possible to tell what changed.
- unicode_data now only sets the bit for a range when characters actually
  fall into the range.  formerly it was setting it when a character
  was <= the endpoint of the current range.  This presumed no gaps in
  the ranges, but there are gaps.