### PR TITLE
Clean up unicode_data.py a bit, and update callers.

### DIFF
--- a/nototools/lang_data.py
+++ b/nototools/lang_data.py
@@ -92,7 +92,7 @@ def _create_lang_data():
     if not is_excluded_script(script):
       all_lang_scripts[lang].add(script)
 
-  for script in unicode_data.all_script_codes():
+  for script in unicode_data.all_scripts():
     if is_excluded_script(script):
       continue
     lang = cldr_data.get_likely_subtags('und-' + script)[0]

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -56,8 +56,8 @@ def convert_to_four_letter(script_name):
   if not script_name:
     raise ValueError('empty script name')
   if script_name in ODD_SCRIPTS:
-      return ODD_SCRIPTS[script_name]
-  script_code = unicode_data.scripe_code(script_name)
+    return ODD_SCRIPTS[script_name]
+  script_code = unicode_data.script_code(script_name)
   if script_code = 'Zzzz':
     if len(script_name) != 4:
       raise ValueError('no script for %s' % script_name)

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -57,7 +57,14 @@ def convert_to_four_letter(script_name):
     raise ValueError('empty script name')
   if script_name in ODD_SCRIPTS:
       return ODD_SCRIPTS[script_name]
-  return unicode_data.web_script_code(script_name)
+  script_code = unicode_data.scripe_code(script_name)
+  if script_code = 'Zzzz':
+    if len(script_name) != 4:
+      raise ValueError('no script for %s' % script_name)
+    print >> sys.std_err, 'defaulting script for %s' % script_name
+    script_code = script_name
+  return script_code
+
 
 # NotoFont maps a font path to information we assume the font to have, based on Noto
 # path and naming conventions:

--- a/nototools/unicode_data_test.py
+++ b/nototools/unicode_data_test.py
@@ -110,7 +110,7 @@ class UnicodeDataTest(unittest.TestCase):
         self.assertEqual(unicode_data.age(0x20BD), '7.0')
         self.assertEqual(unicode_data.age(0x2B820), '8.0')
         # below will fail once unicode 9 character age data updates
-        self.assertIsNone(unicode_data.age(0x104b0))
+        self.assertIsNone(unicode_data.age(0x104B0))
 
     def test_bidi_mirroring_glyph(self):
         """Tests the bidi_mirroring_glyph() method."""

--- a/nototools/unicode_data_test.py
+++ b/nototools/unicode_data_test.py
@@ -108,7 +108,9 @@ class UnicodeDataTest(unittest.TestCase):
         self.assertEqual(unicode_data.age(0xE000), '1.1')
         self.assertEqual(unicode_data.age(0xE0021), '3.1')
         self.assertEqual(unicode_data.age(0x20BD), '7.0')
-        self.assertIsNone(unicode_data.age(0x2B820))
+        self.assertEqual(unicode_data.age(0x2B820), '8.0')
+        # below will fail once unicode 9 character age data updates
+        self.assertIsNone(unicode_data.age(0x104b0))
 
     def test_bidi_mirroring_glyph(self):
         """Tests the bidi_mirroring_glyph() method."""
@@ -131,7 +133,8 @@ class UnicodeDataTest(unittest.TestCase):
                          'Greek')
         self.assertEqual(unicode_data.human_readable_script_name('Talu'),
                          'New Tai Lue')
-        self.assertEqual(unicode_data.human_readable_script_name('Nkoo'), 'NKo')
+        self.assertEqual(unicode_data.human_readable_script_name('Nkoo'),
+                         'N\'Ko')
         self.assertEqual(unicode_data.human_readable_script_name('Qaae'),
                          'Emoji')
         self.assertEqual(unicode_data.human_readable_script_name('Zsym'),


### PR DESCRIPTION
- removes redundant 'all_script_codes' method
- updates unicode_data_test for partial unicode 9 data
- changes 'human readable name' of N'Ko and Phags-Pa
- does less work on-the-fly when matching script code names
- removes web_script_code and puts this variant into only caller