### PR TITLE
Use new standard script codes in place of private use codes.

### DIFF
--- a/nototools/extra_locale_data.py
+++ b/nototools/extra_locale_data.py
@@ -486,14 +486,6 @@ EXEMPLARS = {
   'und-Mtei': r'[\uabc0-\uabe2]',
   'und-Orkh': r'[\U010c00-\U010c48]',
   'und-Phag': r'[\ua840-\ua877]',
-  'und-Qaae': r'[\u2049\u231a\u231b\u2600\u260e\u2614\u2615\u26fa\u2708\u2709'
-              r'\u270f\u3297\U01f004\U01f170\U01f193\U01f197\U01f30d\U01f318'
-              r'\U01f332\U01f334\U01f335\U01f344\U01f346\U01f352\U01f381'
-              r'\U01f393\U01f3a7\U01f3b8\U01f3e1\U01f402\U01f40a\U01f418'
-              r'\U01f419\U01f41b\U01f41f\U01f422\U01f424\U01f427\U01f44c'
-              r'\U01f44d\U01f453\U01f463\U01f4bb\U01f4ce\U01f4d3\U01f4d6'
-              r'\U01f4e1\U01f4fb\U01f511\U01f525\U01f565\U01F63a\U01f680'
-              r'\U01f681\U01f683\U01f686\U01f68c\U01f6a2\U01f6a3\U01f6b4]',
   'und-Saur': r'[\ua882-\ua8b3]',
   'und-Sund': r'[\u1b83-\u1ba0]',
   'und-Sylo': r'[\ua800-\ua82b]',
@@ -501,6 +493,14 @@ EXEMPLARS = {
   'und-Tglg': r'[\u1700-\u170c \u170e-\u1711]',
   'und-Ugar': r'[\U010380-\U01039d \U01039f]',
   'und-Xsux': r'[\U012000-\U01202f]',
+  'und-Zsye': r'[\u2049\u231a\u231b\u2600\u260e\u2614\u2615\u26fa\u2708\u2709'
+              r'\u270f\u3297\U01f004\U01f170\U01f193\U01f197\U01f30d\U01f318'
+              r'\U01f332\U01f334\U01f335\U01f344\U01f346\U01f352\U01f381'
+              r'\U01f393\U01f3a7\U01f3b8\U01f3e1\U01f402\U01f40a\U01f418'
+              r'\U01f419\U01f41b\U01f41f\U01f422\U01f424\U01f427\U01f44c'
+              r'\U01f44d\U01f453\U01f463\U01f4bb\U01f4ce\U01f4d3\U01f4d6'
+              r'\U01f4e1\U01f4fb\U01f511\U01f525\U01f565\U01F63a\U01f680'
+              r'\U01f681\U01f683\U01f686\U01f68c\U01f6a2\U01f6a3\U01f6b4]',
   'und-Zsym': r'[\u20ac\u20b9\u2103\u2109\u2115\u2116\u211a\u211e\u2122'
               r'\u21d0-\u21d3\u2203\u2205\u2207\u2208\u220f\u221e\u2248\u2284'
               r'\u231a\u23e3\u23f3\u2400\u2460\u24b6\u2523\u2533\u2602\u260e'

--- a/nototools/lang_data.py
+++ b/nototools/lang_data.py
@@ -114,7 +114,7 @@ def _create_lang_data():
   all_lang_scripts['ryu'].add('Jpan')
 
   # Patch: see noto-fonts#133 comment on June 8th.
-  all_lang_scripts['tlh'] |= {'Latn', 'Qaak'} # see wikipedia Klingon_alphabets
+  all_lang_scripts['tlh'] |= {'Latn', 'Piqd'}
 
   all_langs = used_lang_scripts.keys() + all_lang_scripts.keys()
   lang_data = {}
@@ -168,10 +168,10 @@ def _create_script_to_default_lang(lang_script_data):
 
   # Add scripts without langs.
   all_scripts.add('Zsym')
-  all_scripts.add('Qaae')
+  all_scripts.add('Zsye')
 
-  # Patch Klingon as default lang for pseudo-script pIqaD
-  script_to_used['Qaak'].add('tlh')
+  # Patch Klingon as default lang for (unused) script pIqaD
+  script_to_used['Piqd'].add('tlh')
 
   for script in sorted(all_scripts):
     default_lang = cldr_data.get_likely_subtags('und-' + script)[0]
@@ -230,7 +230,7 @@ def _create_lang_script_to_names(lang_script_data):
         en_name = cldr_data.get_english_language_name(target)
       if not en_name:
         # Easier than patching the cldr_data, not sure I want to go there.
-        if lang_script == 'tlh-Qaak':
+        if lang_script == 'tlh-Piqd':
           en_name = u'Klingon'
         else:
           print '!No english name for %s' % lang_script

--- a/nototools/noto_data.py
+++ b/nototools/noto_data.py
@@ -114,7 +114,7 @@ DEEMED_UI_SCRIPTS_SET = frozenset({
   'Geor', # Georgian
   'Hebr', # Hebrew
   'Sinh', # Sinhala
-  'Qaae', # Emoji
+  'Zsye', # Emoji
 })
 
 # Range spec matches "Noto Nastaliq requirements" doc, Tier 1.

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -48,7 +48,7 @@ ODD_SCRIPTS = {
   'NKo': 'Nkoo',
   'SumeroAkkadianCuneiform': 'Xsux',
   'Symbols': 'Zsym',
-  'Emoji': 'Qaae',
+  'Emoji': 'Zsye',
 }
 
 
@@ -137,7 +137,7 @@ def get_noto_font(filepath, family_name='Arimo|Cousine|Tinos|Noto'):
   # Special-case emoji style
   # (style can be None for e.g. Cousine, causing 'in' to fail, so guard)
   if style and 'Emoji' in style:
-    script = 'Qaae'
+    script = 'Zsye'
     if style == 'ColorEmoji':
       style = 'Emoji'
       variant = 'color'
@@ -240,6 +240,8 @@ def noto_font_to_family_id(notofont):
     tags.append(notofont.family)
   if notofont.style:
     tags.append(notofont.style)
+  if notofont.is_mono and not notofont.is_cjk:
+    tags.append('mono')
   if notofont.is_cjk and notofont.subset:
     tags.append('cjk')
     tags.append(notofont.subset)
@@ -320,7 +322,8 @@ def get_families(fonts):
       else:
         unhinted_members.append(font)
       if not rep_member:
-        if font.weight == 'Regular' and font.slope is None and not font.is_mono:
+        if font.weight == 'Regular' and font.slope is None and not (
+            font.is_cjk and font.is_mono):
           # We assume here that there's no difference between a hinted or unhinted
           # rep_member in terms of what we use it for.  The other filters are to ensure
           # the fontTools font name is a good stand-in for the family name.

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -395,15 +395,15 @@ def printable_font_versions(font):
 
 
 HARD_CODED_FONT_INFO = {
-    "AndroidEmoji.ttf": ("Sans", "Qaae", None, "Regular"),
-    "DroidEmoji.ttf": ("Sans", "Qaae", None, "Regular"),
-    "NotoEmoji-Regular.ttf": ("", "Qaae", None, "Regular"),
+    "AndroidEmoji.ttf": ("Sans", "Zsye", None, "Regular"),
+    "DroidEmoji.ttf": ("Sans", "Zsye", None, "Regular"),
+    "NotoEmoji-Regular.ttf": ("", "Zsye", None, "Regular"),
     "NotoNaskh-Regular.ttf": ("Naskh", "Arab", None, "Regular"),
     "NotoNaskh-Bold.ttf": ("Naskh", "Arab", None, "Bold"),
     "NotoNaskhUI-Regular.ttf": ("Naskh", "Arab", "UI", "Regular"),
     "NotoNaskhUI-Bold.ttf": ("Naskh", "Arab", "UI", "Bold"),
     "NotoSansCypriotSyllabary-Regular.ttf": ("Sans", "Cprt", None, "Regular"),
-    "NotoSansEmoji-Regular.ttf": ("Sans", "Qaae", None, "Regular"),
+    "NotoSansEmoji-Regular.ttf": ("Sans", "Zsye", None, "Regular"),
     "NotoSansKufiArabic-Regular.ttf": ("Kufi", "Arab", None, "Regular"),
     "NotoSansKufiArabic-Bold.ttf": ("Kufi", "Arab", None, "Bold"),
     "NotoSansSymbols-Regular.ttf": ("Sans", "Zsym", None, "Regular"),
@@ -597,7 +597,7 @@ def check_font(font_props, filename_error,
         'Aran': 'Urdu',
         'HST': 'Historic',
         'LGC': None,
-        'Qaae': None,
+        'Zsye': None,
     }
 
     def _get_expected_noncjk_family_name():
@@ -871,7 +871,7 @@ def check_font(font_props, filename_error,
 
     def _get_script_required(cmap):
         needed_chars = set()
-        if font_props.script == "Qaae":  # Emoji
+        if font_props.script == "Zsye":  # Emoji
             # TODO: Check emoji coverage
             needed_chars = _emoji_pua_set()  # legacy PUA for android emoji
         elif font_props.script == "Zsym":  # Symbols
@@ -1043,7 +1043,7 @@ def check_font(font_props, filename_error,
                      check_test=False)
 
         if tests.check('cmap/disallowed_ascii') and not (
-            font_props.script == "Qaae" or
+            font_props.script == "Zsye" or
             font_props.script == "Latn" or
             font_props.script == "LGC" or
             font_props.is_cjk):

--- a/nototools/unicode_data.py
+++ b/nototools/unicode_data.py
@@ -280,10 +280,13 @@ def script_code(script_name):
 
 
 _HARD_CODED_HUMAN_READABLE_SCRIPT_NAMES = {
+    'Aran': 'Nastaliq', # not assigned
     'Nkoo': 'N\'Ko',
-    'Qaae': 'Emoji',
-    'Zsym': 'Symbols',
     'Phag': 'Phags-Pa',
+    'Piqd': 'Klingon', # not assigned
+    'Zmth': 'Math', # not assigned
+    'Zsye': 'Emoji', # not assigned
+    'Zsym': 'Symbols', # not assigned
 }
 
 _HARD_CODED_FOLDED_SCRIPT_NAME_TO_CODE = {

--- a/nototools/unicode_data_test.py
+++ b/nototools/unicode_data_test.py
@@ -135,7 +135,7 @@ class UnicodeDataTest(unittest.TestCase):
                          'New Tai Lue')
         self.assertEqual(unicode_data.human_readable_script_name('Nkoo'),
                          'N\'Ko')
-        self.assertEqual(unicode_data.human_readable_script_name('Qaae'),
+        self.assertEqual(unicode_data.human_readable_script_name('Zsye'),
                          'Emoji')
         self.assertEqual(unicode_data.human_readable_script_name('Zsym'),
                          'Symbols')


### PR DESCRIPTION
- Qaae -> Zsye, Qaak -> Piqd

Fixes nototools#139.

Oh, just noticed a fix for monospace fonts slipped in here.