### PR TITLE
Add tools to generate and compare cmap data from various sources.

### DIFF
--- a/nototools/cmap_data.py
+++ b/nototools/cmap_data.py
@@ -151,10 +151,11 @@ def write_cmap_data(cmap_data, pretty=False):
   return ET.tostring(_build_tree(cmap_data, pretty).getroot(), encoding='utf-8')
 
 
-def create_metadata(program, args=[], date=datetime.date.today()):
+def create_metadata(program, args=None, date=datetime.date.today()):
   """Create a MetaData object from the program, args, and date."""
-  str_args = [(str(arg[0]), str(arg[1])) for arg in args]
-  return MetaData(str(date), program, str_args)
+  return MetaData(
+      str(date), program,
+      [] if not args else [(str(arg[0]), str(arg[1])) for arg in args])
 
 
 def create_table(header, rows):
@@ -168,9 +169,8 @@ def create_table(header, rows):
   for row in rows:
     row = [t.strip() for t in row.split(',')]
     if len(row) != len(header):
-      print >> sys.stderr, 'table has %d cols but row[%d] has %d' % (
-          len(header), len(rowdatas), len(row))
-      raise ValueError('row cols mismatch')
+      raise ValueError('table has %d cols but row[%d] has %d' % (
+          len(header), len(rowdatas), len(row)))
     rowdatas.append(RowData(*row))
   return TableData(header=header, rows=rowdatas)
 

--- a/nototools/cmap_data.py
+++ b/nototools/cmap_data.py
@@ -1,0 +1,218 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import datetime
+
+from nototools import lint_config
+from nototools import noto_lint
+
+from xml.etree import ElementTree as ET
+
+"""Functions for reading/writing cmap data in xml format.
+
+This data is represented by a CmapData object, which consists of
+MetaData and TableData.  MetaData consists of the date, the program
+name, and args, which is a list of arg, value tuples.  TableData
+consists of a list of headers, and a list of RowData objects with
+fields named after the headers.
+
+Currently the cmap data metadata holds information about how the
+data was generated, and the table the generated data.  There are
+four columns: script code, script name, the number of codepoints, and
+the codepoints represnted as a string of hex values and ranges
+separated by space.  This format is not enforced by all the related
+functions in this file, though it is used by the code that converts
+between a map from script to cpset and a TableData."""
+
+MetaData = collections.namedtuple('MetaData', 'date, program, args')
+TableData = collections.namedtuple('TableData', 'header, rows')
+CmapData = collections.namedtuple('CmapData', 'meta, table')
+
+
+def _prettify(root, indent=''):
+  """Pretty-print the root element if it has no text and children
+     by adding to the root text and each child's tail."""
+  if not root.text and len(root):
+    indent += '  '
+    sfx = '\n' + indent
+    root.text = sfx
+    for elem in root:
+      elem.tail = sfx
+      _prettify(elem, indent)
+    elem.tail = sfx[:-2]
+
+
+def _read_meta(meta_node):
+  """Return a MetaData object for the 'meta' element."""
+  date = meta_node.get('date')
+  program = meta_node.get('program')
+  args = []
+  args_node = meta_node.find('args')
+  if args_node is not None:
+    for arg_node in args_node:
+      key = arg_node.tag
+      val = arg_node.get('val').strip()
+      args.append((key, val))
+  return MetaData(date, program, args)
+
+
+def _read_table(table_node):
+  """Return a TableData object for the 'table' element."""
+  header = []
+  rows = []
+  for node in table_node:
+    if node.tag == 'th':
+      if header:
+        raise ValueError('cannot handle multiple headers')
+      elif rows:
+        raise ValueError('encountered header after rows')
+      else:
+        header = node.text.strip()
+    elif node.tag == 'tr':
+      rows.append(node.text.strip())
+  return create_table(header, rows)
+
+
+def _read_tree(root):
+  """Return a CmapData object for the 'cmapdata' element."""
+  meta = _read_meta(root.find('meta'))
+  table = _read_table(root.find('table'))
+  return CmapData(meta, table)
+
+
+def _build_meta(metadata):
+  """Create an xml 'meta' element for the MetaData object."""
+  meta = ET.Element('meta', date=metadata.date, program=metadata.program)
+  if metadata.args:
+    args = ET.Element('args')
+    for k, v in metadata.args:
+      arg = ET.Element(k, {'val': v})
+      args.append(arg)
+    meta.append(args)
+  return meta
+
+
+def _build_table(tabledata):
+  """Create an xml 'table' element for the TableData object."""
+  table = ET.Element('table', nrows=str(len(tabledata.rows)))
+  if tabledata.header:
+    header = ET.Element('th')
+    header.text = ','.join(tabledata.header)
+    table.append(header)
+  for rowdata in tabledata.rows:
+    row = ET.Element('tr')
+    row_items = [getattr(rowdata, h, '') for h in tabledata.header]
+    row.text = ','.join(row_items)
+    table.append(row)
+  return table
+
+
+def _build_tree(cmap_data, pretty=False):
+  """Create an xml 'cmapdata' element for the CmapData object."""
+  root = ET.Element('cmapdata')
+  def opt_append(elem):
+    if elem != None:
+      root.append(elem)
+  opt_append(_build_meta(cmap_data.meta))
+  opt_append(_build_table(cmap_data.table))
+  if pretty:
+    _prettify(root)
+  return ET.ElementTree(element=root)
+
+
+def read_cmap_data_file(filename):
+  return _read_tree(ET.parse(filename).getroot())
+
+
+def read_cmap_data(text):
+  return _read_tree(ET.fromstring(text))
+
+
+def write_cmap_data_file(cmap_data, filename, pretty=False):
+  _build_tree(cmap_data, pretty).write(
+      filename, encoding='utf-8', xml_declaration=True)
+
+
+def write_cmap_data(cmap_data, pretty=False):
+  return ET.tostring(_build_tree(cmap_data, pretty).getroot(), encoding='utf-8')
+
+
+def create_metadata(program, args=[], date=datetime.date.today()):
+  """Create a MetaData object from the program, args, and date."""
+  str_args = [(str(arg[0]), str(arg[1])) for arg in args]
+  return MetaData(str(date), program, str_args)
+
+
+def create_table(header, rows):
+  """Create a TableData object from the header and rows.  Header
+  is a string, rows is a list of strings.  In each, columns are
+  separated by ',' which cannot otherwise appear in the text.
+  Each row must have the same number of columns as the header does."""
+  header = [t.strip() for t in header.split(',')]
+  RowData = collections.namedtuple('RowData', header)
+  rowdatas = []
+  for row in rows:
+    row = [t.strip() for t in row.split(',')]
+    if len(row) != len(header):
+      print >> sys.stderr, 'table has %d cols but row[%d] has %d' % (
+          len(header), len(rowdatas), len(row))
+      raise ValueError('row cols mismatch')
+    rowdatas.append(RowData(*row))
+  return TableData(header=header, rows=rowdatas)
+
+
+def create_table_from_map(script_to_cmap):
+  """Create a table from a map from script to cmaps.  Outputs
+  the script code, script name, count of code points, and the
+  codepoint ranges in hex separated by space."""
+  table_header = 'script,name,count,ranges'.split(',')
+  RowData = collections.namedtuple('RowData', table_header)
+
+  table_rows = []
+  for script in sorted(script_to_cmap):
+    cmap = script_to_cmap.get(script)
+    name = noto_lint.script_name_for_report(script)
+    count = len(cmap)
+    cp_ranges = lint_config.write_int_ranges(cmap)
+    table_rows.append(RowData(script, name, str(count), cp_ranges))
+  return TableData(table_header, table_rows)
+
+
+def create_map_from_table(table):
+  """Create a map from script code to cmap."""
+  assert table.header == 'script,name,count,ranges'.split(',')
+  return {rd.script: rd for rd in table.rows}
+
+
+def _test():
+  meta =  create_metadata('test', [('this', 5), ('that', 12.3)])
+  table = create_table('foo,bar', [
+      '1,5.3',
+      '2,6.4',
+      ])
+  cmapdata = CmapData(meta, table)
+  print cmapdata
+  xml_text = write_cmap_data(cmapdata)
+  newdata = read_cmap_data(xml_text)
+  print newdata
+  write_cmap_data_file(cmapdata, 'test_cmap_data.xml', pretty=True)
+  newdata = read_cmap_data_file('test_cmap_data.xml')
+  print newdata
+
+
+if __name__ == "__main__":
+  _test()

--- a/nototools/compare_cmap_data.py
+++ b/nototools/compare_cmap_data.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+#
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare two cmap data files produced by lint_cmap_reqs or
+   noto_font_cmaps."""
+
+import argparse
+
+from nototools import cmap_data
+from nototools import lint_config
+from nototools import unicode_data
+
+
+def title_from_metadata(metadata):
+  items = [metadata.date, metadata.program]
+  if metadata.args:
+    items.extend(['%s=%s' % t for t in metadata.args])
+  return ' '.join(items)
+
+
+def compare_cmap_data(base_cmap_data, target_cmap_data, scripts, cps,
+                      except_scripts, except_cps, no_additions, no_removals):
+  result = {}
+  base_map = cmap_data.create_map_from_table(base_cmap_data.table)
+  target_map = cmap_data.create_map_from_table(target_cmap_data.table)
+
+  for script in sorted(base_map):
+    if except_scripts and script in except_scripts:
+      continue
+    if scripts and script not in scripts:
+      continue
+    if script in target_map:
+      name = base_map[script].name
+      base_cps = lint_config.parse_int_ranges(base_map[script].ranges)
+      target_cps = lint_config.parse_int_ranges(target_map[script].ranges)
+      if cps:
+        base_cps &= cps
+        target_cps &= cps
+      if except_cps:
+        base_cps -= except_cps
+        target_cps -= except_cps
+      if base_cps != target_cps:
+        added = None if no_additions else target_cps - base_cps
+        removed = None if no_removals else base_cps - target_cps
+      else:
+        added, removed = None, None
+      result[script] = (added, removed)
+  return result
+
+
+def compare_cmap_data_files(base_file, target_file, scripts, ranges,
+                            except_scripts, except_ranges,
+                            no_additions, no_removals):
+  base_cmap_data = cmap_data.read_cmap_data_file(base_file)
+  target_cmap_data = cmap_data.read_cmap_data_file(target_file)
+  compare = compare_cmap_data(
+      base_cmap_data, target_cmap_data, scripts, ranges,
+      except_scripts, except_ranges, no_additions, no_removals)
+  return compare, base_cmap_data, target_cmap_data
+
+
+def report_compare(compare_result, detailed=True):
+  compare, base_cmap_data, target_cmap_data = compare_result
+  base_map = cmap_data.create_map_from_table(base_cmap_data.table)
+  target_map = cmap_data.create_map_from_table(target_cmap_data.table)
+
+  base_title = title_from_metadata(base_cmap_data.meta)
+  target_title = title_from_metadata(target_cmap_data.meta)
+
+  print 'base: %s' % base_title
+  print 'target: %s' % target_title
+  for script in sorted(compare):
+    added, removed = compare[script]
+    if added or removed:
+      name = base_map[script].name
+      print '%s # %s' % (script, name)
+      if added:
+        print '  added (%d): %s' % (
+            len(added), lint_config.write_int_ranges(added))
+        if detailed:
+          for cp in sorted(added):
+            print '    %6s %s' % (
+                '%04x' % cp, unicode_data.name(cp, ''))
+      if removed:
+        print '  removed (%d): %s' % (
+            len(removed), lint_config.write_int_ranges(removed))
+        if detailed:
+          for cp in sorted(removed):
+            print '    %6s %s' % (
+                '%04x' % cp, unicode_data.name(cp, ''))
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-b', '--base', help='base cmap data file',
+      metavar='file', required=True)
+  parser.add_argument(
+      '-t', '--target', help='target cmap data file',
+      metavar='file', required=True)
+  parser.add_argument(
+      '-s', '--scripts', help='only these scripts (except ignored)',
+      metavar='code', nargs='+')
+  parser.add_argument(
+      '-r', '--ranges', help='only these ranges (except ignored)',
+      metavar='ranges', nargs='+')
+  parser.add_argument(
+      '-xs', '--except_scripts', help='ignore these scripts',
+      metavar='code', nargs='+')
+  parser.add_argument(
+      '-xr', '--except_ranges', help='ignore these codepoints',
+      metavar='ranges', nargs='+')
+  parser.add_argument(
+      '-na', '--no_additions', help='do not report additions (in target '
+      'but not base)', action='store_true')
+  parser.add_argument(
+      '-nr', '--no_removals', help='do not report removals (in base '
+      'but not target)', action='store_true')
+
+  args = parser.parse_args()
+  if args.scripts:
+    scripts = set(args.scripts)
+  else:
+    scripts = None
+
+  if args.ranges:
+    cps = lint_config.parse_int_ranges(' '.join(args.ranges))
+  else:
+    cps = None
+
+  if args.except_ranges:
+    except_cps = lint_config.parse_int_ranges(' '.join(args.except_ranges))
+  else:
+    except_cps = None
+
+  if args.except_scripts:
+    except_scripts = set(args.except_scripts)
+  else:
+    except_scripts = None
+
+  result = compare_cmap_data_files(
+      args.base, args.target, scripts, cps, except_scripts, except_cps,
+      args.no_additions, args.no_removals)
+  report_compare(result)
+
+
+if __name__ == "__main__":
+  main()

--- a/nototools/compare_cmap_data.py
+++ b/nototools/compare_cmap_data.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nototools/lint_cmap_reqs.py
+++ b/nototools/lint_cmap_reqs.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract what lint expects for cmap from our data."""
+
+import argparse
+import sys
+
+from nototools import lint_config
+from nototools import noto_data
+from nototools import noto_lint
+from nototools import opentype_data
+from nototools import unicode_data
+from nototools import cmap_data
+
+_PHASE_TWO_SCRIPTS = """
+  Arab, Aran, Armi, Armn, Avst, Bali, Bamu, Batk, Beng, Brah, Bugi, Buhd, Cans,
+  Cari, Cham, Cher, Copt, Cprt, Deva, Dsrt, Egyp, Ethi, Geor, Glag, Goth, Gujr,
+  Guru, Hano, Hans, Hant, Hebr, Ital, Java, Jpan, Kali, Khar, Khmr, Knda, Kore,
+  Kthi, LGC, Lana, Laoo, Lepc, Limb, Linb, Lisu, Lyci, Lydi, Mand, Mlym, Mong,
+  Mtei, Mymr, Nkoo, Ogam, Olck, Orkh, Orya, Osma, Phag, Phli, Phnx, Prti, Qaae,
+  Rjng, Runr, Samr, Sarb, Saur, Shaw, Sinh, Sund, Sylo, Syrc, Tagb, Tale, Talu,
+  Taml, Tavt, Telu, Tfng, Tglg, Thaa, Thai, Tibt, Ugar, Vaii, Xpeo, Xsux, Yiii,
+  Zsym
+"""
+
+def code_range_to_set(code_range):
+  """Converts a code range output by _parse_code_ranges to a set."""
+  characters = set()
+  for first, last, _ in code_range:
+      characters.update(range(first, last+1))
+  return frozenset(characters)
+
+
+_SYMBOL_SET = None
+
+def _symbol_set():
+  """Returns set of characters that should be supported in Noto Symbols.
+  """
+  global _SYMBOL_SET
+
+  if not _SYMBOL_SET:
+    ranges = unicode_data._parse_code_ranges(noto_data.SYMBOL_RANGES_TXT)
+    _SYMBOL_SET = code_range_to_set(ranges) & unicode_data.defined_characters()
+  return _SYMBOL_SET
+
+
+def _cjk_set():
+  """Returns set of characters that will be provided in CJK fonts.
+  """
+  ranges = unicode_data._parse_code_ranges(noto_data.CJK_RANGES_TXT)
+  return code_range_to_set(ranges) & unicode_data.defined_characters()
+
+
+def _emoji_pua_set():
+  """Returns the legacy PUA characters required for Android emoji."""
+  return lint_config.parse_int_ranges('FE4E5-FE4EE FE82C FE82E-FE837')
+
+
+def _get_script_required(script, unicode_version, unicode_only, verbose=False):
+  needed_chars = set()
+  if script == "Qaae":
+    # TODO: Check emoji coverage
+    if not unicode_only:
+      needed_chars = _emoji_pua_set()  # legacy PUA for android emoji
+  elif script == "Zsym":
+    if not unicode_only:
+      needed_chars = _symbol_set()
+  elif script == "LGC":
+    needed_chars = (
+        unicode_data.defined_characters(scr="Latn")
+        | unicode_data.defined_characters(scr="Grek")
+        | unicode_data.defined_characters(scr="Cyrl"))
+    if not unicode_only:
+      needed_chars -= _symbol_set()
+      needed_chars -= _cjk_set()
+  elif script == "Aran":
+    if unicode_only:
+      needed_chars = unicode_data.defined_characters(scr='Arab')
+    else:
+      needed_chars = noto_data.urdu_set()
+  elif script in ['Hans', 'Hant', 'Jpan', 'Kore']:
+      needed_chars = _cjk_set()
+  else:
+    needed_chars = unicode_data.defined_characters(scr=script)
+    if not unicode_only:
+      needed_chars -= _symbol_set()
+
+  needed_chars &= unicode_data.defined_characters(version=unicode_version)
+
+  if not unicode_only and script != 'Aran':
+    try:
+      needed_chars |= set(noto_data.EXTRA_CHARACTERS_NEEDED[script])
+    except KeyError:
+      pass
+
+    try:
+      needed_chars |= set(opentype_data.SPECIAL_CHARACTERS_NEEDED[script])
+    except KeyError:
+      pass
+
+    try:
+      needed_chars -= set(noto_data.CHARACTERS_NOT_NEEDED[script])
+    except KeyError:
+      pass
+
+  if not unicode_only:
+    needed_chars |= set([0, 0xd, 0x20])
+
+  if verbose:
+    print >> sys.stderr, script,
+
+  return needed_chars
+
+
+def _check_scripts(scripts):
+  # TODO(dougfelt): something realer
+  bad_scripts = []
+  for script in scripts:
+    if script[0] < 'A' or script[0] > 'Z':
+      bad_scripts.append(script)
+  if bad_scripts:
+    print 'bad scripts: %s' % ', '.join(bad_scripts)
+    raise ValueError('bad scripts')
+
+  return set(scripts)
+
+
+def get_cmap_data(scripts, unicode_version, unicode_only, verbose):
+  metadata = cmap_data.create_metadata('lint_cmap_reqs', [
+      ('unicode_version', unicode_version),
+      ('unicode_only', unicode_only)])
+  tabledata = cmap_data.create_table_from_map({
+      script : _get_script_required(
+          script, unicode_version, unicode_only, verbose)
+      for script in sorted(scripts)
+    })
+  return cmap_data.CmapData(metadata, tabledata)
+
+
+def main():
+  DEFAULT_UNICODE_VERSION = 9.0
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--scripts', help='list of pseudo-script codes, empty for all '
+      'phase 2 scripts', metavar='code', nargs='*')
+  parser.add_argument(
+      '--unicode_version', help='version of unicode to use (default %s)' %
+      DEFAULT_UNICODE_VERSION, metavar='version', type=float,
+      default=DEFAULT_UNICODE_VERSION)
+  parser.add_argument(
+      '--unicode_only', help='only use unicode data, not noto-specific data',
+      action='store_true')
+  parser.add_argument(
+      '--outfile', help='write to output file, otherwise to stdout',
+      metavar='fname', nargs='?', const='-default-')
+  parser.add_argument(
+      '--verbose', help='log to stderr as each script is complete',
+      action='store_true')
+  args = parser.parse_args()
+
+  if not args.scripts:
+    scripts = set(s.strip() for s in _PHASE_TWO_SCRIPTS.split(','))
+  else:
+    scripts = _check_scripts(args.scripts)
+
+  cmapdata = get_cmap_data(
+      scripts, args.unicode_version, args.unicode_only, args.verbose)
+  if args.outfile:
+    if args.outfile == '-default-':
+      args.outfile = 'lint_cmap_%s.xml' % args.unicode_version
+    print >> sys.stderr, 'writing %s' % args.outfile
+    cmap_data.write_cmap_data_file(cmapdata, args.outfile, pretty=True)
+  else:
+    print cmap_data.write_cmap_data(cmapdata, pretty=True)
+
+if __name__ == "__main__":
+  main()

--- a/nototools/lint_cmap_reqs.py
+++ b/nototools/lint_cmap_reqs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nototools/mti_cmap_data.py
+++ b/nototools/mti_cmap_data.py
@@ -42,7 +42,7 @@ def get_script_to_cmap(csvdata):
   header = None
   data = None
   for n, r in enumerate(csvdata.splitlines()):
-    r = r.strip();
+    r = r.strip()
     if not r:
       continue
     rowdata = r.split(',')
@@ -56,9 +56,7 @@ def get_script_to_cmap(csvdata):
       raise ValueError('row %d had %d cols but expected %d:\n"%s"' % (
           n, len(rowdata), ncols, r))
     for i, v in enumerate(rowdata):
-      v = v.strip()
-      if v.endswith('*'):
-        v = v[:-1]
+      v = v.strip(' \n\t*')
       if not v or v == u'\u001a':
         continue
       try:

--- a/nototools/mti_cmap_data.py
+++ b/nototools/mti_cmap_data.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract cmap data from mti phase 3 spreadsheet."""
+
+import argparse
+from os import path
+import sys
+
+from nototools import cmap_data
+from nototools import unicode_data
+
+
+def get_script_for_name(script_name):
+  if script_name in ['LGC']:
+    return script_name
+
+  code = unicode_data.script_code(script_name)
+  if code == 'Zzzz':
+    raise ValueError('cannot identify script for "%s"' % script_name)
+  return code
+
+
+def get_script_to_cmap(csvdata):
+  # Roll our own parse, the data is simple... well, mostly.
+  # Google sheets inconsistently puts ^Z in first empty cell in a column.
+  # Also, MTI puts asterisks into the data to mark some values, which is just
+  # noise for our purposes.
+  header = None
+  data = None
+  for n, r in enumerate(csvdata.splitlines()):
+    r = r.strip();
+    if not r:
+      continue
+    rowdata = r.split(',')
+    if not header:
+      header = [get_script_for_name(name) for name in rowdata]
+      ncols = len(header)
+      data = [set() for _ in range(ncols)]
+      continue
+
+    if len(rowdata) != ncols:
+      raise ValueError('row %d had %d cols but expected %d:\n"%s"' % (
+          n, len(rowdata), ncols, r))
+    for i, v in enumerate(rowdata):
+      v = v.strip()
+      if v.endswith('*'):
+        v = v[:-1]
+      if not v or v == u'\u001a':
+        continue
+      try:
+        data[i].add(int(v, 16))
+      except:
+        raise ValueError('could not parse col %d of row %d: "%s" %x' % (
+            i, n, v, ord(v[0])))
+  return { script: cmap for script, cmap in zip(header, data) }
+
+
+def cmap_data_from_csv(csvdata, infile=None):
+  args = [('infile', infile)] if infile else None
+  metadata = cmap_data.create_metadata('mti_cmap_data', args)
+  tabledata = cmap_data.create_table_from_map(
+      get_script_to_cmap(csvdata))
+  return cmap_data.CmapData(metadata, tabledata)
+
+
+def cmap_data_from_csv_file(csvfile):
+  with open(csvfile, 'r') as f:
+    csvdata = f.read()
+  return cmap_data_from_csv(csvdata, csvfile)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--infile', help='input file name', metavar='fname')
+  parser.add_argument(
+      '--outfile', help='write to output file, otherwise to stdout, '
+      'provide file name or will default to one based on infile',
+      metavar='fname', nargs='?', const='-default-')
+  args = parser.parse_args()
+
+  cmapdata = cmap_data_from_csv_file(args.infile)
+  if args.outfile:
+    if args.outfile == '-default-':
+      args.outfile = path.splitext(path.basename(args.infile))[0] + '.xml'
+    print >> sys.stderr, 'writing %s' % args.outfile
+    cmap_data.write_cmap_data_file(cmapdata, args.outfile, pretty=True)
+  else:
+    print cmap_data.write_cmap_data(cmapdata, pretty=True)
+
+
+if __name__ == "__main__":
+  main()

--- a/nototools/noto_font_cmaps.py
+++ b/nototools/noto_font_cmaps.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+#
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dump cmap info from noto font familes in lint_cmap_reqs format."""
+
+import argparse
+import collections
+import datetime
+import os
+from os import path
+import sys
+
+from fontTools import ttLib
+
+from nototools import cldr_data
+from nototools import cmap_data
+from nototools import lint_config
+from nototools import noto_data
+from nototools import noto_fonts
+from nototools import noto_lint
+from nototools import opentype_data
+from nototools import unicode_data
+
+
+def report_set_differences(name_to_cpset, out=sys.stderr):
+  """Report differences, assuming they are small."""
+
+  # this does ok with 2 or 3 highly overlapping sets, but it will
+  # be unintelligible in other cases.
+
+  additional = ''
+  while len(name_to_cpset):
+    common = None
+    if len(name_to_cpset) > 1:
+      for name, cpset in name_to_cpset.iteritems():
+        if common == None:
+          common = cpset.copy()
+        else:
+          common &= cpset
+    if common:
+      name = ', '.join(sorted(name_to_cpset))
+      print >> out, '%d%s in common among %s:' % (
+          len(common), additional, name)
+      print >> out, lint_config.write_int_ranges(common)
+
+      for name, cpset in sorted(name_to_cpset.iteritems()):
+        extra = cpset - common
+        if extra:
+          name_to_cpset[name] = extra
+        else:
+          print >> out, '%s has no additional' % name
+          del name_to_cpset[name]
+      additional = ' additional'
+      continue
+
+    for name, cpset in sorted(name_to_cpset.iteritems()):
+      print >> out, '%s has %d%s:' % (name, len(cpset), additional)
+      print >> out, lint_config.write_int_ranges(cpset)
+    break
+
+
+def font_cmap_data():
+  """Return CmapData for (almost) all the noto font families."""
+  metadata = cmap_data.create_metadata('noto_font_cmaps')
+
+  def use_in_web(font):
+    return (not font.subset and
+            not font.is_UI and
+            not font.fmt == 'ttc' and
+            not font.script in {'CJK', 'HST'} and
+            not font.family in {'Arimo', 'Cousine', 'Tinos'})
+  fonts = filter(use_in_web, noto_fonts.get_noto_fonts())
+  families = noto_fonts.get_families(fonts)
+
+  ScriptData = collections.namedtuple('ScriptData', 'family_name,script,cpset')
+  script_to_data = collections.defaultdict(list)
+  for family in families.values():
+    script = family.rep_member.script
+    family_name = family.name
+    cpset = family.charset
+    script_to_data[script].append(ScriptData(family_name, script, cpset))
+
+  def report_data_error(index, script_data):
+    print >> sys.stderr, '  %d: %s, %d, %s' % (
+        index, script_data.family_name, script_data.script,
+        len(script_data.cpset),
+        lint_config.write_int_ranges(script_data.cpset))
+
+  script_to_cmap = {}
+  for script in sorted(script_to_data):
+    data = script_to_data[script]
+    selected_cpset = data[0].cpset
+    if len(data) > 1:
+      differ = False
+      for i in range(1, len(data)):
+        test_data = data[i]
+        for j in range(i):
+          if data[j].cpset != test_data.cpset:
+            differ = True
+        if len(test_data.cpset) > len(selected_cpset):
+          selected_cpset = test_data.cpset
+      if differ:
+        print >> sys.stderr, '\nscript %s cmaps differ' % script
+        differences = { i.family_name:i.cpset for i in data }
+        report_set_differences(differences)
+    script_to_cmap[script] = selected_cpset
+
+  tabledata = cmap_data.create_table_from_map(script_to_cmap)
+  return cmap_data.CmapData(metadata, tabledata)
+
+
+def main():
+  cmapdata = font_cmap_data()
+  cmap_data.write_cmap_data_file(cmapdata, 'font_cmaps.xml', pretty=True)
+
+if __name__ == "__main__":
+  main()

--- a/nototools/noto_font_cmaps.py
+++ b/nototools/noto_font_cmaps.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ def font_cmap_data():
           selected_cpset = test_data.cpset
       if differ:
         print >> sys.stderr, '\nscript %s cmaps differ' % script
-        differences = { i.family_name:i.cpset for i in data }
+        differences = {i.family_name: i.cpset for i in data}
         report_set_differences(differences)
     script_to_cmap[script] = selected_cpset
 


### PR DESCRIPTION
The cmap data is organized per script and written to an xml format.  It
is sourced from a number of places: (a copy of) the lint code, the noto font
families, planning spreadsheets from MTI.  There are separate tools to
extract data from each source, a common set of utilities to read/write
the xml files, and a tool to compare the files.