### PR TITLE
[minor] check before del; test for oblique flag

### DIFF
--- a/nototools/font_data.py
+++ b/nototools/font_data.py
@@ -210,7 +210,8 @@ def delete_from_cmap(font, chars):
     for table in cmap_table.tables:
         if (table.format, table.platformID, table.platEncID) in UNICODE_CMAPS:
             for char in chars:
-                del table.cmap[char]
+                if char in table.cmap:
+                    del table.cmap[char]
 
 
 def add_to_cmap(font, mapping):

--- a/nototools/unittests/font_tests.py
+++ b/nototools/unittests/font_tests.py
@@ -87,6 +87,7 @@ class TestMetaInfo(FontTest):
     """Test various meta information."""
 
     mark_heavier_as_bold = False
+    mark_italic_as_oblique = False
 
     def setUp(self):
         _, self.fonts = self.loaded_fonts
@@ -114,6 +115,8 @@ class TestMetaInfo(FontTest):
         for font in self.fonts:
             bold, italic = self.parse_metadata(font)
             expected_fs_type = ((bold << 5) | italic) or (1 << 6)
+            if italic and self.mark_italic_as_oblique:
+                expected_fs_type |= (1 << 9)
             self.assertEqual(font['OS/2'].fsSelection, expected_fs_type)
 
     def test_fs_type(self):


### PR DESCRIPTION
These are small changes which shouldn't affect any existing use of
nototools. One change checks that a char is in a cmap before deleting
it. The other adds an option in the unit tests to check the oblique
flag in italic fonts' fsSelection field.