### PR TITLE
Add a "fontdiff" package for comparing fonts

### DIFF
--- a/nototools/fontdiff/__main__.py
+++ b/nototools/fontdiff/__main__.py
@@ -1,3 +1,28 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides the command-line utility `fontdiff`.
+
+Leverages GposDiffFinder or ShapeDiffFinder, depending on what's given via the
+`diff_type` argument. Can compare multiple font pairs via the `match` argument.
+For shaping comparisons, all results are sorted together and the largest
+differences from all pairs are shown first. For GPOS the pairs are still
+compared separately.
+"""
+
+
 import argparse
 import glob
 import os
@@ -34,13 +59,21 @@ def run_multiple(func, filematch, dir_a, dir_b, *args):
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('path_a')
-    parser.add_argument('path_b')
-    parser.add_argument('-t', '--diff_type', default='shape')
-    parser.add_argument('-m', '--match')
-    parser.add_argument('-l', '--out_lines', type=int, default=20)
-    parser.add_argument('-w', '--whitelist', nargs='+')
+    parser = argparse.ArgumentParser(description='Compare fonts or ttxn output '
+                                     'pointed to by PATH_A and PATH_B.')
+    parser.add_argument('path_a', metavar='PATH_A')
+    parser.add_argument('path_b', metavar='PATH_B')
+    parser.add_argument('-t', '--diff_type', default='shape',
+                        help='type of comparison to run, "shape" or "gpos" '
+                        '(defaults to "shape"), if "gpos" is provided the '
+                        'input paths should point to ttxn output')
+    parser.add_argument('-m', '--match',
+                        help='if provided, compares all matching files found '
+                        'in PATH_A with respective matches in PATH_B')
+    parser.add_argument('-l', '--out_lines', type=int, default=20,
+                        help='number of differences to print (default 20)')
+    parser.add_argument('-w', '--whitelist', nargs='+',
+                        help='list of one or more glyph names to ignore')
     args = parser.parse_args()
 
     if args.diff_type == 'shape':

--- a/nototools/fontdiff/__main__.py
+++ b/nototools/fontdiff/__main__.py
@@ -1,0 +1,73 @@
+import argparse
+import glob
+import os
+
+from nototools.fontdiff import gpos_diff, shape_diff
+
+
+def shape(path_a, path_b, stats):
+    cur_stats = []
+    diff_finder = shape_diff.ShapeDiffFinder(
+        path_a, path_b, output_lines=-1, ratio_diffs=True)
+
+    diff_finder.find_area_diffs(cur_stats)
+
+    basename = os.path.basename(path_a)
+    stats.extend(s[0:2] + (basename,) + s[2:] for s in cur_stats)
+
+
+def gpos(path_a, path_b, out_lines):
+    print '-- %s --' % os.path.basename(path_a)
+    print
+    diff_finder = gpos_diff.GposDiffFinder(path_a, path_b, 3, out_lines)
+    print diff_finder.find_kerning_diffs()
+    print diff_finder.find_mark_class_diffs()
+    print diff_finder.find_positioning_diffs()
+    print diff_finder.find_positioning_diffs(mark_type='mark')
+    print
+
+
+def run_multiple(func, filematch, dir_a, dir_b, *args):
+    for path_a in glob.glob(os.path.join(dir_a, filematch)):
+        path_b = path_a.replace(dir_a, dir_b)
+        func(path_a, path_b, *args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('path_a')
+    parser.add_argument('path_b')
+    parser.add_argument('-t', '--diff_type', default='shape')
+    parser.add_argument('-m', '--match')
+    parser.add_argument('-l', '--out_lines', type=int, default=20)
+    parser.add_argument('-w', '--whitelist', nargs='+')
+    args = parser.parse_args()
+
+    if args.diff_type == 'shape':
+        stats = []
+        if args.match:
+            run_multiple(shape, args.match, args.path_a, args.path_b, stats)
+        else:
+            shape(args.path_a, args.path_b, stats)
+
+        if not stats:
+            print 'No shape differences found.'
+            return
+
+        if args.whitelist:
+            stats = [s for s in stats if s[1] not in args.whitelist]
+        stats.sort()
+        stats.reverse()
+        for diff, glyph, font, val_a, val_b in stats[:args.out_lines]:
+            print '%s %s %s (%s vs %s)' % (font, glyph, diff, val_a, val_b)
+
+    else:
+        if args.match:
+            run_multiple(gpos, args.match, args.path_a, args.path_b,
+                         args.out_lines)
+        else:
+            gpos(args.path_a, args.path_b, args.out_lines)
+
+
+if __name__ == '__main__':
+    main()

--- a/nototools/fontdiff/gpos_diff.py
+++ b/nototools/fontdiff/gpos_diff.py
@@ -1,3 +1,31 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides GposDiffFinder, which finds differences in ttxn feature output.
+
+GposDiffFinder takes in two paths, to plaintext files containing the output of
+ttxn. It provides methods which compare the OpenType feature contents of these
+files: `find_kerning_diffs`, `find_mark_class_diffs`, and
+`find_positioning_diffs`.
+
+Unlike ShapeDiffFinder, the methods don't have a `stats` argument and can't
+accumulate a report between method calls (yet?). They simply report the
+differences via a returned string.
+"""
+
+
 from collections import defaultdict
 import re
 

--- a/nototools/fontdiff/gpos_diff.py
+++ b/nototools/fontdiff/gpos_diff.py
@@ -1,0 +1,201 @@
+from collections import defaultdict
+import re
+
+
+class GposDiffFinder:
+    """Provides methods to report diffs in GPOS content between ttxn outputs."""
+
+    def __init__(self, file_a, file_b, error_bound, output_lines=6):
+        with open(file_a) as ifile:
+            self.text_a = ifile.read()
+        with open(file_b) as ifile:
+            self.text_b = ifile.read()
+        self.err = error_bound
+        self.out_lines = output_lines
+
+    def find_kerning_diffs(self):
+        """Report differences in kerning rules."""
+
+        classes_a, classes_b = {}, {}
+        rx = re.compile(r'(@[\w\d_.]+) = \[([\s\w\d_.]+)\];')
+        self._parse_kerning_classes(rx, self.text_a, classes_a)
+        self._parse_kerning_classes(rx, self.text_b, classes_b)
+
+        unmatched = defaultdict(list)
+        mismatched = defaultdict(list)
+        rx = re.compile('pos ([\w\d@_.]+) ([\w\d@_.]+) (-?\d+);')
+        self._parse_kerning(rx, '-', self.text_a, classes_a, unmatched)
+        self._parse_kerning(rx, '+', self.text_b, classes_b, unmatched)
+        self._organize_kerning_diffs(unmatched, mismatched)
+
+        unmatched = [(k, v) for k, v in unmatched.iteritems() if v]
+        res = ['%d differences in kerning pairs' % len(unmatched)]
+        unmatched.sort(self._compare_keys)
+        for (sign, left, right), vals in unmatched[:self.out_lines]:
+            res.append('%s pos %s %s %s' % (sign, left, right, vals))
+        res.append('')
+
+        mismatched = [(k, v) for k, v in mismatched.iteritems() if any(v)]
+        res.append('%d differences in kerning values' % len(mismatched))
+        mismatched.sort(self._compare_kerning_values)
+        for (left, right), (vals1, vals2) in mismatched[:self.out_lines]:
+            if sum(abs(v1 - v2) for v1, v2 in zip(vals1, vals2)) > self.err:
+                res.append('pos %s %s: %s vs %s' % (left, right, vals1, vals2))
+        res.append('')
+        return '\n'.join(res)
+
+    def find_mark_class_diffs(self):
+        """Report differences in mark class definitions."""
+
+        unmatched = {}
+        mismatched = {}
+        rx = re.compile('mark \[([\w\d\s@_.]+)\] <anchor (-?\d+) (-?\d+)> '
+                        '(@[\w\d_.]+);')
+        self._parse_anchor_info(rx, '-', self.text_a, unmatched, mismatched)
+        self._parse_anchor_info(rx, '+', self.text_b, unmatched, mismatched)
+
+        res = ['%d differences in mark class definitions' % len(unmatched)]
+        unmatched = unmatched.items()
+        unmatched.sort(self._compare_keys)
+        for (sign, member, mark_class), (x, y) in unmatched[:self.out_lines]:
+            res.append('%s mark [%s] <anchor %d %d> %s;' %
+                       (sign, member, x, y, mark_class))
+        res.append('')
+
+        res.append('%d differences in mark class values' % len(mismatched))
+        mismatched = mismatched.items()
+        mismatched.sort(self._compare_anchors)
+        for (member, cls), ((x1, y1), (x2, y2)) in mismatched[:self.out_lines]:
+            if abs(x1 - x2) > self.err or abs(y1 - y2) > self.err:
+                res.append('%s %s <%d %d> vs <%d %d>' %
+                           (member, cls, x1, y1, x2, y2))
+        res.append('')
+        return '\n'.join(res)
+
+    def find_positioning_diffs(self, mark_type='base'):
+        """Report differences in positioning rules."""
+
+        unmatched = {}
+        mismatched = {}
+        rx = re.compile('pos %s \[([\w\d\s@_.]+)\]\s+<anchor (-?\d+) (-?\d+)> '
+                        'mark (@[\w\d_.]+);' % mark_type)
+        self._parse_anchor_info(rx, '-', self.text_a, unmatched, mismatched)
+        self._parse_anchor_info(rx, '+', self.text_b, unmatched, mismatched)
+
+        res = ['%d differences in mark-to-%s positioning rule coverage' %
+               (len(unmatched), mark_type)]
+        unmatched = unmatched.items()
+        unmatched.sort(self._compare_keys)
+        for (sign, member, mark_class), (x, y) in unmatched[:self.out_lines]:
+            res.append('%s pos %s [%s] <anchor %d %d> mark %s;' %
+                       (sign, mark_type, member, x, y, mark_class))
+        res.append('')
+
+        res.append('%d differences in mark-to-%s positioning rule values' %
+                   (len(mismatched), mark_type))
+        mismatched = mismatched.items()
+        mismatched.sort(self._compare_anchors)
+        for (member, cls), ((x1, y1), (x2, y2)) in mismatched[:self.out_lines]:
+            if abs(x1 - x2) > self.err or abs(y1 - y2) > self.err:
+                res.append('%s %s <%d %d> vs <%d %d>' %
+                           (member, cls, x1, y1, x2, y2))
+        res.append('')
+        return '\n'.join(res)
+
+    def _parse_kerning_classes(self, rx, text, classes):
+        """Parse kerning class definitions."""
+
+        for definition in rx.findall(text):
+            name, members = definition
+            classes[name] = members.split()
+
+    def _parse_kerning(self, rx, sign, text, classes, unmatched):
+        """Parse kerning rules."""
+
+        for rule in rx.findall(text):
+            left, right, val = rule
+            val = int(val)
+            if left in classes:
+                left = classes[left]
+            else:
+                left = [left]
+            if right in classes:
+                right = classes[right]
+            else:
+                right = [right]
+
+            for left_glyph in left:
+                for right_glyph in right:
+                    key = sign, left_glyph, right_glyph
+                    key_match = (self._reverse_sign(sign), left_glyph,
+                                 right_glyph)
+                    if val in unmatched[key_match]:
+                        unmatched[key_match].remove(val)
+                    else:
+                        unmatched[key].append(val)
+
+    def _organize_kerning_diffs(self, unmatched, mismatched):
+        """Move mismatched kerning rules into a separate dictionary."""
+
+        keys = unmatched.keys()
+        for key in keys:
+            if key not in unmatched:  # already matched and removed
+                continue
+            sign, left, right = key
+            key_match = self._reverse_sign(sign), left, right
+            if (key_match in unmatched and
+                len(unmatched[key]) == len(unmatched[key_match])):
+                if sign == '+':
+                    key, key_match = key_match, key
+                mismatched[left, right] = (
+                    unmatched.pop(key), unmatched.pop(key_match))
+
+    def _parse_anchor_info(self, rx, sign, text, unmatched, mismatched):
+        """Parse unmatched and mismatched mark classes."""
+
+        for members, x, y, mark_class in rx.findall(text):
+            # hack to get around unexpected class naming differences (ttxn bug?)
+            mark_class = '_'.join(mark_class.split('_', 2)[:2])
+            for member in members.split():
+                val = int(x), int(y)
+                key_match = self._reverse_sign(sign), member, mark_class
+                if key_match in unmatched:
+                    if unmatched[key_match] != val:
+                        mismatched[member, mark_class] = (
+                            unmatched[key_match], val)
+                    del unmatched[key_match]
+                else:
+                    unmatched[sign, member, mark_class] = val
+
+    def _compare_anchors(self, left, right):
+        """Compare differences between anchors, putting larger diffs first."""
+
+        _, ((x1, y1), (x2, y2)) = left
+        left_diff = abs(x1 - x2) + abs(y1 - y2)
+        _, ((x1, y1), (x2, y2)) = right
+        right_diff = abs(x1 - x2) + abs(y1 - y2)
+        return right_diff - left_diff
+
+    def _compare_kerning_values(self, left, right):
+        """Compare differences between kerning values, larger diffs first."""
+
+        _, (vals1, vals2) = left
+        left_diff = sum(abs(v1 - v2) for v1, v2 in zip(vals1, vals2))
+        _, (vals1, vals2) = right
+        right_diff = sum(abs(v1 - v2) for v1, v2 in zip(vals1, vals2))
+        return right_diff - left_diff
+
+    def _compare_keys(self, left, right):
+        """Compare items with keys of form (sign, data...) ignoring the sign."""
+
+        return cmp(''.join(left[0][1:]), ''.join(right[0][1:]))
+
+    def _reverse_sign(self, sign):
+        """Return the reverse of a sign contained in a string."""
+
+        if sign == '-':
+            return '+'
+        elif sign == '+':
+            return '-'
+        else:
+            raise ValueError('Bad sign "%s".' % sign)

--- a/nototools/fontdiff/shape_diff.py
+++ b/nototools/fontdiff/shape_diff.py
@@ -1,3 +1,34 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides ShapeDiffFinder, which finds differences in OTF/TTF glyph shapes.
+
+ShapeDiffFinder takes in two paths, to font binaries. It then provides methods
+which compare these fonts, returning a report string and optionally adding to a
+report dictionary. These methods are `find_area_diffs`, which compares glyph
+areas, and `find_rendered_diffs` which compares harfbuzz output using image
+magick.
+
+Neither comparison is ideal. Glyph areas can be the same even if the shapes are
+wildly different. Image comparison is usually either slow (hi-res) or inaccurate
+(lo-res), and can be easily hindered when one glyph's image is a pixel larger
+than another's. Still, these are usually useful for raising red flags and
+catching large errors.
+"""
+
+
 import os
 import subprocess
 
@@ -45,7 +76,7 @@ class ShapeDiffFinder:
         report.append('')
 
     def find_rendered_diffs(self, font_size=24, stats=None):
-        """Find diffs of glyphs as rendered by image magick."""
+        """Find diffs of glyphs as rendered by harfbuzz."""
 
         self.build_names()
         self.build_reverse_cmap()

--- a/nototools/fontdiff/shape_diff.py
+++ b/nototools/fontdiff/shape_diff.py
@@ -1,0 +1,200 @@
+import os
+import subprocess
+
+from fontTools.ttLib import TTFont
+from nototools.pens.glyph_area_pen import GlyphAreaPen
+
+
+class ShapeDiffFinder:
+    """Provides methods to report diffs in glyph shapes between OT Fonts."""
+
+    def __init__(self, file_a, file_b, output_lines=6, ratio_diffs=False):
+        self.paths = file_a, file_b
+        self.fonts = [TTFont(f) for f in self.paths]
+        self.out_lines = output_lines
+        self.ratio_diffs = ratio_diffs
+        self.report = []
+
+    def find_area_diffs(self, stats=None):
+        """Report differences in glyph areas."""
+
+        self.build_names()
+
+        glyph_sets =[f.getGlyphSet() for f in self.fonts]
+        glyph_set_a, glyph_set_b = glyph_sets
+        pen_a, pen_b = [GlyphAreaPen(glyph_set) for glyph_set in glyph_sets]
+
+        mismatched = {}
+        for name in self.names:
+            glyph_set_a[name].draw(pen_a)
+            area_a = pen_a.unload()
+            glyph_set_b[name].draw(pen_b)
+            area_b = pen_b.unload()
+            if area_a != area_b:
+                mismatched[name] = (area_a, area_b)
+
+        report = self.report
+        report.append('%d differences in glyph areas' % len(mismatched))
+        mismatched = self._sorted_by(
+            mismatched.items(),
+            self._calc_ratio if self.ratio_diffs else self._calc_diff)
+        for diff, name, (area1, area2) in mismatched[:self.out_lines]:
+            report.append('%s: %s vs %s' % (name, area1, area2))
+            if stats is not None:
+                stats.append((diff, name, area1, area2))
+        report.append('')
+
+    def find_rendered_diffs(self, font_size=24, stats=None):
+        """Find diffs of glyphs as rendered by image magick."""
+
+        self.build_names()
+        self.build_reverse_cmap()
+
+        path_a, path_b = self.paths
+        ordered_names = list(self.names)
+        a_png = 'tmp_a.png'
+        b_png = 'tmp_b.png'
+        cmp_png = 'tmp_cmp.png'
+        diffs_filename = 'tmp_diffs.txt'
+
+        with open(diffs_filename, 'w') as ofile:
+            for name in ordered_names:
+
+                # ignore null character, and characters without unicode values
+                unival = self.reverse_cmap.get(name, 0)
+                if unival == 0:
+                    continue
+
+                strin = unichr(unival)
+                subprocess.call([
+                    'hb-view', '--font-size=%d' % font_size,
+                    '--output-file=%s' % a_png, path_a, strin])
+                subprocess.call([
+                    'hb-view', '--font-size=%d' % font_size,
+                    '--output-file=%s' % b_png, path_b, strin])
+                subprocess.call(
+                    ['compare', '-metric', 'AE', a_png, b_png, cmp_png],
+                    stderr=ofile)
+
+        with open(diffs_filename) as ifile:
+            diffs = ifile.readlines()
+
+        os.remove(a_png)
+        os.remove(b_png)
+        os.remove(cmp_png)
+        os.remove(diffs_filename)
+
+        mismatched = {}
+        img_size_diffs = []
+        for name, diff in zip(ordered_names, diffs):
+            if 'image widths or heights differ' in diff:
+                img_size_diffs.append(name)
+            elif int(diff) != 0:
+                mismatched[name] = int(diff)
+
+        report = self.report
+        report.append('%d differences in rendered glyphs' % len(mismatched))
+        mismatched = self._sorted_by(
+            mismatched.items(), self._pass_val)
+        for _, name, diff in mismatched[:self.out_lines]:
+            report.append('%s: %s' % (name, diff))
+            if stats is not None:
+                stats.append((diff, name))
+        report.append('')
+
+        report.append('%d differences in glyph img size' % len(img_size_diffs))
+        img_size_diffs.sort()
+        for name in img_size_diffs[:self.out_lines]:
+            report.append(name)
+        report.append('')
+
+    def build_names(self):
+        """Build a list of glyph names shared between the fonts."""
+
+        if hasattr(self, 'names'):
+            return
+
+        report = self.report
+        names_a, names_b = [set(f.getGlyphOrder()) for f in self.fonts]
+        if names_a != names_b:
+            report.append("Glyph coverage doesn't match")
+            report.append('  in A but not B: %s' % list(names_a - names_b))
+            report.append('  in B but not A: %s' % list(names_b - names_a))
+            report.append('')
+        self.names = names_a & names_b
+
+    def build_reverse_cmap(self):
+        """Build a map from glyph names to unicode values for the fonts."""
+
+        if hasattr(self, 'reverse_cmap'):
+            return
+
+        report = self.report
+        reverse_cmaps = [
+            dict((n, v) for v, n in f['cmap'].tables[1].cmap.items())
+            for f in self.fonts]
+        mismatched = {}
+        for name in self.names:
+            unival_a, unival_b = [m.get(name) for m in reverse_cmaps]
+            if unival_a != unival_b:
+                mismatched[name] = (unival_a, unival_b)
+        if mismatched:
+            report.append("Glyph unicode values don't match")
+            for name, univals in mismatched.items():
+                univals = [(('0x%04X' % v) if v else str(v)) for v in univals]
+                report.append('  %s: %s in A, %s in B' %
+                              (name, univals[0], univals[1]))
+            report.append('')
+        self.reverse_cmap = reverse_cmaps[0]
+
+    def dump(self):
+        """Return the results of run diffs."""
+        return '\n'.join(self.report)
+
+    def _sorted_by(self, items, diff_calc):
+        """Return items, sorted by diff_calc with calculated diff included."""
+
+        items = list(items)
+        items.sort(lambda lhs, rhs: self._compare(lhs, rhs, diff_calc))
+        return [(diff_calc(vals), name, vals) for name, vals in items]
+
+    def _compare(self, left, right, diff_calc):
+        """Compare glyph area diffs by magnitude then glyph name.
+
+        Args:
+            left, right: Tuples each containing a glyph name and then an
+                argument to diff_calc (usually the argument would be a tuple
+                containing two areas for the glyph from different fonts).
+            diff_calc: A function which calculates an area diff for a glyph. For
+                now this either calculates the difference of two areas, or the
+                ratio, or just passes through a pre-computed diff.
+
+        Returns:
+            An integer value for use in a sorting function.
+        """
+
+        (lname, lvals), (rname, rvals) = left, right
+        dl = diff_calc(lvals)
+        dr = diff_calc(rvals)
+        return -1 if dl > dr else 1 if dr > dl else cmp(lname, rname)
+
+    def _pass_val(self, val):
+        """Pass through a pre-computed area diff."""
+
+        return val
+
+    def _calc_diff(self, vals):
+        """Calculate an area difference."""
+
+        return abs(vals[0] - vals[1])
+
+    def _calc_ratio(self, vals):
+        """Calculate an area ratio."""
+
+        a, b = vals
+        if not (a or b):
+            return 0
+        if abs(a) > abs(b):
+            a, b = b, a
+        ratio = (a / b) if (a and b) else 0
+        return (1 - ratio)

--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,9 @@ setup(name='nototools',
                'nototools/scale.py',
                'nototools/subset.py',
                'nototools/subset_symbols.py',
-               'nototools/test_vertical_extents.py'])
+               'nototools/test_vertical_extents.py'],
+      entry_points={
+          'console_scripts': [
+              'fontdiff = nototools.fontdiff.__main__:main',
+          ]
+      })


### PR DESCRIPTION
This might be generally useful for comparing a font against another
font which you know to be correct. Currently tools here compare glyph
shapes and positioning (GPOS) features.

The tools try to put largest diffs first, so even if there are many
diffs you can just look at the first few, which should be the most
significant. For glyph shapes, multiple pairs of fonts can be compared
at once and the diffs from all pairs sorted together.

For positioning features, ttxn output is compared rather than actual
font binaries. ttxn is a tool bundled in the AFDKO, see description:
http://www.adobe.com/devnet/opentype/afdko/topic_overview.html
Effectively, de-compiled feature syntax is being compared rather than
the GPOS tables.

Sorry for the large PR! I should have pushed this earlier....

cc @davelab6