### PR TITLE
Add phase 2/3 family name info files, update lint.

### DIFF
--- a/nototools/family_name_info_p2.xml
+++ b/nototools/family_name_info_p2.xml
@@ -1,0 +1,123 @@
+<?xml version='1.0' encoding='utf8'?>
+<family_name_data date="2016-01-22">
+  <info family="Arimo" />
+  <info family="Cousine" />
+  <info family="Noto" use_preferred="t" use_wws="t" />
+  <info family="Noto Color Emoji" />
+  <info family="Noto Emoji" />
+  <info family="Noto Kufi Arabic" />
+  <info family="Noto Naskh Arabic" use_preferred="t" use_wws="t" />
+  <info family="Noto Nastaliq Urdu" />
+  <info family="Noto Sans" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Armenian" />
+  <info family="Noto Sans Avestan" />
+  <info family="Noto Sans Balinese" />
+  <info family="Noto Sans Bamum" />
+  <info family="Noto Sans Batak" />
+  <info family="Noto Sans Bengali" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Brahmi" />
+  <info family="Noto Sans Buginese" />
+  <info family="Noto Sans Buhid" />
+  <info family="Noto Sans CJK JP" limit_original="t" />
+  <info family="Noto Sans CJK KR" limit_original="t" />
+  <info family="Noto Sans CJK SC" limit_original="t" />
+  <info family="Noto Sans CJK TC" limit_original="t" />
+  <info family="Noto Sans Canadian Aboriginal" />
+  <info family="Noto Sans Carian" />
+  <info family="Noto Sans Cham" />
+  <info family="Noto Sans Cherokee" />
+  <info family="Noto Sans Coptic" />
+  <info family="Noto Sans Cuneiform" />
+  <info family="Noto Sans Cypriot" />
+  <info family="Noto Sans Deseret" />
+  <info family="Noto Sans Devanagari" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Egyptian Hieroglyphs" />
+  <info family="Noto Sans Ethiopic" />
+  <info family="Noto Sans Georgian" />
+  <info family="Noto Sans Glagolitic" />
+  <info family="Noto Sans Gothic" />
+  <info family="Noto Sans Gujarati" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Gurmukhi" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Hanunoo" />
+  <info family="Noto Sans Hebrew" />
+  <info family="Noto Sans Imperial Aramaic" />
+  <info family="Noto Sans Inscriptional Pahlavi" />
+  <info family="Noto Sans Inscriptional Parthian" />
+  <info family="Noto Sans JP" limit_original="t" />
+  <info family="Noto Sans Javanese" />
+  <info family="Noto Sans KR" limit_original="t" />
+  <info family="Noto Sans Kaithi" />
+  <info family="Noto Sans Kannada" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Kayah Li" />
+  <info family="Noto Sans Kharoshthi" />
+  <info family="Noto Sans Khmer" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Lao" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Lepcha" />
+  <info family="Noto Sans Limbu" />
+  <info family="Noto Sans Linear B" />
+  <info family="Noto Sans Lisu" />
+  <info family="Noto Sans Lycian" />
+  <info family="Noto Sans Lydian" />
+  <info family="Noto Sans Malayalam" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Mandaic" />
+  <info family="Noto Sans Meetei Mayek" />
+  <info family="Noto Sans Mongolian" />
+  <info family="Noto Sans Mono CJK JP" limit_original="t" />
+  <info family="Noto Sans Mono CJK KR" limit_original="t" />
+  <info family="Noto Sans Mono CJK SC" limit_original="t" />
+  <info family="Noto Sans Mono CJK TC" limit_original="t" />
+  <info family="Noto Sans Myanmar" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans N'Ko" />
+  <info family="Noto Sans New Tai Lue" />
+  <info family="Noto Sans Ogham" />
+  <info family="Noto Sans Ol Chiki" />
+  <info family="Noto Sans Old Italic" />
+  <info family="Noto Sans Old Persian" />
+  <info family="Noto Sans Old South Arabian" />
+  <info family="Noto Sans Old Turkic" />
+  <info family="Noto Sans Oriya" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Osmanya" />
+  <info family="Noto Sans Phags-Pa" />
+  <info family="Noto Sans Phoenician" />
+  <info family="Noto Sans Rejang" />
+  <info family="Noto Sans Runic" />
+  <info family="Noto Sans SC" limit_original="t" />
+  <info family="Noto Sans Samaritan" />
+  <info family="Noto Sans Saurashtra" />
+  <info family="Noto Sans Shavian" />
+  <info family="Noto Sans Sinhala" />
+  <info family="Noto Sans Sundanese" />
+  <info family="Noto Sans Syloti Nagri" />
+  <info family="Noto Sans Symbols" />
+  <info family="Noto Sans Syriac Eastern" />
+  <info family="Noto Sans Syriac Estrangela" />
+  <info family="Noto Sans Syriac Western" />
+  <info family="Noto Sans TC" limit_original="t" />
+  <info family="Noto Sans Tagalog" />
+  <info family="Noto Sans Tagbanwa" />
+  <info family="Noto Sans Tai Le" />
+  <info family="Noto Sans Tai Tham" />
+  <info family="Noto Sans Tai Viet" />
+  <info family="Noto Sans Tamil" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Telugu" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Thaana" />
+  <info family="Noto Sans Thai" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Tibetan" />
+  <info family="Noto Sans Tifinagh" />
+  <info family="Noto Sans Ugaritic" />
+  <info family="Noto Sans Vai" />
+  <info family="Noto Sans Yi" />
+  <info family="Noto Serif" />
+  <info family="Noto Serif Armenian" />
+  <info family="Noto Serif Bengali" />
+  <info family="Noto Serif Georgian" />
+  <info family="Noto Serif Gujarati" />
+  <info family="Noto Serif Kannada" />
+  <info family="Noto Serif Khmer" />
+  <info family="Noto Serif Lao" />
+  <info family="Noto Serif Malayalam" />
+  <info family="Noto Serif Tamil" />
+  <info family="Noto Serif Telugu" />
+  <info family="Noto Serif Thai" />
+  <info family="Tinos" />
+</family_name_data>

--- a/nototools/family_name_info_p3.xml
+++ b/nototools/family_name_info_p3.xml
@@ -1,0 +1,123 @@
+<?xml version='1.0' encoding='utf8'?>
+<family_name_data date="2016-02-01">
+  <info family="Arimo" />
+  <info family="Cousine" />
+  <info family="Noto" use_preferred="t" use_wws="t" />
+  <info family="Noto Color Emoji" />
+  <info family="Noto Emoji" />
+  <info family="Noto Kufi Arabic" />
+  <info family="Noto Naskh Arabic" use_preferred="t" use_wws="t" />
+  <info family="Noto Nastaliq Urdu" />
+  <info family="Noto Sans" limit_original="t" use_wws="t" />
+  <info family="Noto Sans Armenian" limit_original="t" />
+  <info family="Noto Sans Avestan" />
+  <info family="Noto Sans Balinese" />
+  <info family="Noto Sans Bamum" />
+  <info family="Noto Sans Batak" />
+  <info family="Noto Sans Bengali" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Brahmi" />
+  <info family="Noto Sans Buginese" />
+  <info family="Noto Sans Buhid" />
+  <info family="Noto Sans CJK JP" limit_original="t" />
+  <info family="Noto Sans CJK KR" limit_original="t" />
+  <info family="Noto Sans CJK SC" limit_original="t" />
+  <info family="Noto Sans CJK TC" limit_original="t" />
+  <info family="Noto Sans Canadian Aboriginal" />
+  <info family="Noto Sans Carian" />
+  <info family="Noto Sans Cham" />
+  <info family="Noto Sans Cherokee" />
+  <info family="Noto Sans Coptic" />
+  <info family="Noto Sans Cuneiform" />
+  <info family="Noto Sans Cypriot" />
+  <info family="Noto Sans Deseret" />
+  <info family="Noto Sans Devanagari" limit_original="t" use_wws="t" />
+  <info family="Noto Sans Egyptian Hieroglyphs" />
+  <info family="Noto Sans Ethiopic" />
+  <info family="Noto Sans Georgian" limit_original="t" />
+  <info family="Noto Sans Glagolitic" />
+  <info family="Noto Sans Gothic" />
+  <info family="Noto Sans Gujarati" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Gurmukhi" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Hanunoo" />
+  <info family="Noto Sans Hebrew" />
+  <info family="Noto Sans Imperial Aramaic" />
+  <info family="Noto Sans Inscriptional Pahlavi" />
+  <info family="Noto Sans Inscriptional Parthian" />
+  <info family="Noto Sans JP" limit_original="t" />
+  <info family="Noto Sans Javanese" />
+  <info family="Noto Sans KR" limit_original="t" />
+  <info family="Noto Sans Kaithi" />
+  <info family="Noto Sans Kannada" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Kayah Li" />
+  <info family="Noto Sans Kharoshthi" />
+  <info family="Noto Sans Khmer" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Lao" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Lepcha" />
+  <info family="Noto Sans Limbu" />
+  <info family="Noto Sans Linear B" />
+  <info family="Noto Sans Lisu" />
+  <info family="Noto Sans Lycian" />
+  <info family="Noto Sans Lydian" />
+  <info family="Noto Sans Malayalam" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Mandaic" />
+  <info family="Noto Sans Meetei Mayek" />
+  <info family="Noto Sans Mongolian" />
+  <info family="Noto Sans Mono CJK JP" limit_original="t" />
+  <info family="Noto Sans Mono CJK KR" limit_original="t" />
+  <info family="Noto Sans Mono CJK SC" limit_original="t" />
+  <info family="Noto Sans Mono CJK TC" limit_original="t" />
+  <info family="Noto Sans Myanmar" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans N'Ko" />
+  <info family="Noto Sans New Tai Lue" />
+  <info family="Noto Sans Ogham" />
+  <info family="Noto Sans Ol Chiki" />
+  <info family="Noto Sans Old Italic" />
+  <info family="Noto Sans Old Persian" />
+  <info family="Noto Sans Old South Arabian" />
+  <info family="Noto Sans Old Turkic" />
+  <info family="Noto Sans Oriya" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Osmanya" />
+  <info family="Noto Sans Phags-Pa" />
+  <info family="Noto Sans Phoenician" />
+  <info family="Noto Sans Rejang" />
+  <info family="Noto Sans Runic" />
+  <info family="Noto Sans SC" limit_original="t" />
+  <info family="Noto Sans Samaritan" />
+  <info family="Noto Sans Saurashtra" />
+  <info family="Noto Sans Shavian" />
+  <info family="Noto Sans Sinhala" />
+  <info family="Noto Sans Sundanese" />
+  <info family="Noto Sans Syloti Nagri" />
+  <info family="Noto Sans Symbols" />
+  <info family="Noto Sans Syriac Eastern" />
+  <info family="Noto Sans Syriac Estrangela" />
+  <info family="Noto Sans Syriac Western" />
+  <info family="Noto Sans TC" limit_original="t" />
+  <info family="Noto Sans Tagalog" />
+  <info family="Noto Sans Tagbanwa" />
+  <info family="Noto Sans Tai Le" />
+  <info family="Noto Sans Tai Tham" />
+  <info family="Noto Sans Tai Viet" />
+  <info family="Noto Sans Tamil" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Telugu" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Thaana" />
+  <info family="Noto Sans Thai" use_preferred="t" use_wws="t" />
+  <info family="Noto Sans Tibetan" />
+  <info family="Noto Sans Tifinagh" />
+  <info family="Noto Sans Ugaritic" />
+  <info family="Noto Sans Vai" />
+  <info family="Noto Sans Yi" />
+  <info family="Noto Serif" />
+  <info family="Noto Serif Armenian" limit_original="t" />
+  <info family="Noto Serif Bengali" />
+  <info family="Noto Serif Georgian" limit_original="t" />
+  <info family="Noto Serif Gujarati" />
+  <info family="Noto Serif Kannada" />
+  <info family="Noto Serif Khmer" />
+  <info family="Noto Serif Lao" />
+  <info family="Noto Serif Malayalam" />
+  <info family="Noto Serif Tamil" />
+  <info family="Noto Serif Telugu" />
+  <info family="Noto Serif Thai" />
+  <info family="Tinos" />
+</family_name_data>

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -412,7 +412,6 @@ FontProps = collections.namedtuple(
     'manufacturer, license_type, is_hinted, is_mono, is_UI, is_display, '
     'is_cjk, subset')
 
-FAMILY_TO_NAME_INFO = noto_names.read_family_name_info_file()
 
 def font_properties_from_name(file_path):
     noto_font = noto_fonts.get_noto_font(file_path)
@@ -650,14 +649,16 @@ def check_font(font_props, filename_error,
 
         _check_unused_names()
 
-        names = font_data.get_name_records(font)
         noto_font = _noto_font_from_font_props(font_props)
-
-        name_data = noto_names.name_table_data(noto_font, FAMILY_TO_NAME_INFO)
+        family_to_name_info = noto_names.family_to_name_info_for_phase(
+            noto_phase)
+        name_data = noto_names.name_table_data(noto_font, family_to_name_info)
         if not name_data:
             warn("name/unable_to_check", "Unable to check",
                  "No name data available for this font.")
             return
+
+        names = font_data.get_name_records(font)
 
         def _check_idx(idx, expected, keyname):
           actual = names.get(idx, None)
@@ -2004,7 +2005,7 @@ def main():
     parser.add_argument(
         "-p", "--phase",
         help="set noto phase for lint compatibility (default 3)",
-        type=int, default=3)
+        metavar='phase', type=int, default=3)
 
     arguments = parser.parse_args()
 


### PR DESCRIPTION
This adds family name info files for phase 2 and 3.  Phase 2 was
generated using noto_names on the default noto directories (noto-fonts
hinted and unhinted, noto-emoji, noto-cjk) from the .ttf files; phase
3 data added files generated from the toolchain in noto-source/master_ttf.
Phase 3 files will need to be updated as we get more masters with different
variants (weight, condensed, italic, display, etc.)

Noto_lint was updated to use the --phase flag to control which name info
file to use.  Noto_names was updated to add a --phase flag to default
the filename to write the generated info to when it is not overridden.