### PR TITLE
Change lint to use lint_cmap_reqs for cmap data, and incorporate phase.

### DIFF
--- a/nototools/cmap_data.py
+++ b/nototools/cmap_data.py
@@ -18,7 +18,7 @@ import collections
 import datetime
 
 from nototools import lint_config
-from nototools import noto_lint
+from nototools import noto_fonts # for script_name_for_report
 
 from xml.etree import ElementTree as ET
 
@@ -185,7 +185,7 @@ def create_table_from_map(script_to_cmap):
   table_rows = []
   for script in sorted(script_to_cmap):
     cmap = script_to_cmap.get(script)
-    name = noto_lint.script_name_for_report(script)
+    name = noto_fonts.script_name_for_report(script)
     count = len(cmap)
     cp_ranges = lint_config.write_int_ranges(cmap)
     table_rows.append(RowData(script, name, str(count), cp_ranges))

--- a/nototools/lint_cmap_reqs.py
+++ b/nototools/lint_cmap_reqs.py
@@ -21,10 +21,10 @@ import sys
 
 from nototools import lint_config
 from nototools import noto_data
-from nototools import noto_lint
 from nototools import opentype_data
 from nototools import unicode_data
 from nototools import cmap_data
+
 
 _PHASE_TWO_SCRIPTS = """
   Arab, Aran, Armi, Armn, Avst, Bali, Bamu, Batk, Beng, Brah, Bugi, Buhd, Cans,
@@ -37,32 +37,24 @@ _PHASE_TWO_SCRIPTS = """
   Zsym
 """
 
-def code_range_to_set(code_range):
+def _code_range_to_set(code_range):
   """Converts a code range output by _parse_code_ranges to a set."""
   characters = set()
   for first, last, _ in code_range:
       characters.update(range(first, last+1))
-  return frozenset(characters)
+  return characters
 
-
-_SYMBOL_SET = None
 
 def _symbol_set():
-  """Returns set of characters that should be supported in Noto Symbols.
-  """
-  global _SYMBOL_SET
-
-  if not _SYMBOL_SET:
-    ranges = unicode_data._parse_code_ranges(noto_data.SYMBOL_RANGES_TXT)
-    _SYMBOL_SET = code_range_to_set(ranges) & unicode_data.defined_characters()
-  return _SYMBOL_SET
+  """Returns set of characters that should be supported in Noto Symbols."""
+  ranges = unicode_data._parse_code_ranges(noto_data.SYMBOL_RANGES_TXT)
+  return _code_range_to_set(ranges)
 
 
 def _cjk_set():
-  """Returns set of characters that will be provided in CJK fonts.
-  """
+  """Returns set of characters that will be provided in CJK fonts."""
   ranges = unicode_data._parse_code_ranges(noto_data.CJK_RANGES_TXT)
-  return code_range_to_set(ranges) & unicode_data.defined_characters()
+  return _code_range_to_set(ranges)
 
 
 def _emoji_pua_set():
@@ -70,52 +62,45 @@ def _emoji_pua_set():
   return lint_config.parse_int_ranges('FE4E5-FE4EE FE82C FE82E-FE837')
 
 
-def _get_script_required(script, unicode_version, unicode_only, verbose=False):
+def _get_script_required(
+    script, unicode_version, noto_phase, unicode_only=False, verbose=False):
   needed_chars = set()
-  if script == "Qaae":
+  if script == 'Zsye':  # Emoji
     # TODO: Check emoji coverage
     if not unicode_only:
       needed_chars = _emoji_pua_set()  # legacy PUA for android emoji
-  elif script == "Zsym":
+  elif script == 'Zsym':  # Symbols
     if not unicode_only:
       needed_chars = _symbol_set()
-  elif script == "LGC":
+  elif script == 'LGC':
     needed_chars = (
-        unicode_data.defined_characters(scr="Latn")
-        | unicode_data.defined_characters(scr="Grek")
-        | unicode_data.defined_characters(scr="Cyrl"))
+        unicode_data.defined_characters(scr='Latn', version=unicode_version)
+        | unicode_data.defined_characters(scr='Grek', version=unicode_version)
+        | unicode_data.defined_characters(scr='Cyrl', version=unicode_version))
     if not unicode_only:
       needed_chars -= _symbol_set()
       needed_chars -= _cjk_set()
   elif script == "Aran":
     if unicode_only:
-      needed_chars = unicode_data.defined_characters(scr='Arab')
+      needed_chars = unicode_data.defined_characters(
+          scr='Arab', version=unicode_version)
     else:
       needed_chars = noto_data.urdu_set()
   elif script in ['Hans', 'Hant', 'Jpan', 'Kore']:
       needed_chars = _cjk_set()
   else:
-    needed_chars = unicode_data.defined_characters(scr=script)
+    needed_chars = unicode_data.defined_characters(
+        scr=script, version=unicode_version)
     if not unicode_only:
       needed_chars -= _symbol_set()
 
-  needed_chars &= unicode_data.defined_characters(version=unicode_version)
-
-  if not unicode_only and script != 'Aran':
-    try:
-      needed_chars |= set(noto_data.EXTRA_CHARACTERS_NEEDED[script])
-    except KeyError:
-      pass
-
+  if not unicode_only:
+    needed_chars |= noto_data.get_extra_characters_needed(script, noto_phase)
     try:
       needed_chars |= set(opentype_data.SPECIAL_CHARACTERS_NEEDED[script])
     except KeyError:
       pass
-
-    try:
-      needed_chars -= set(noto_data.CHARACTERS_NOT_NEEDED[script])
-    except KeyError:
-      pass
+    needed_chars -= noto_data.get_characters_not_needed(script, noto_phase)
 
   if not unicode_only:
     needed_chars |= set([0, 0xd, 0x20])
@@ -123,7 +108,36 @@ def _get_script_required(script, unicode_version, unicode_only, verbose=False):
   if verbose:
     print >> sys.stderr, script,
 
+  needed_chars &= unicode_data.defined_characters(version=unicode_version)
+
   return needed_chars
+
+
+def _required_unicode_version(noto_font, noto_phase):
+  if noto_font.family != 'Noto': # e.g. Arimo, Cousine, Tinos
+    return 8.0
+  if noto_phase == 2:
+    return 6.0
+  return 9.0
+
+
+def _compute_required_chars(noto_font, noto_phase):
+  unicode_version = _required_unicode_version(noto_font, noto_phase)
+  needed_chars = _get_script_required(
+      noto_font.script, unicode_version, noto_phase)
+  return frozenset(needed_chars)
+
+
+_REQUIRED_CACHE = {}
+def get_required_chars(noto_font, phase):
+  # Required characters must only depend on family, script, variant, and phase
+  key = '_'.join(filter(None, [
+      noto_font.family, noto_font.script, noto_font.variant, str(phase)]))
+  result = _REQUIRED_CACHE.get(key, None)
+  if not result:
+    result = _compute_required_chars(noto_font, phase)
+    _REQUIRED_CACHE[key] = result
+  return result
 
 
 def _check_scripts(scripts):
@@ -139,13 +153,14 @@ def _check_scripts(scripts):
   return set(scripts)
 
 
-def get_cmap_data(scripts, unicode_version, unicode_only, verbose):
+def get_cmap_data(scripts, unicode_version, noto_phase, unicode_only, verbose):
   metadata = cmap_data.create_metadata('lint_cmap_reqs', [
       ('unicode_version', unicode_version),
+      ('phase', noto_phase),
       ('unicode_only', unicode_only)])
   tabledata = cmap_data.create_table_from_map({
       script : _get_script_required(
-          script, unicode_version, unicode_only, verbose)
+          script, unicode_version, noto_phase, unicode_only, verbose)
       for script in sorted(scripts)
     })
   return cmap_data.CmapData(metadata, tabledata)
@@ -166,6 +181,9 @@ def main():
       '--unicode_only', help='only use unicode data, not noto-specific data',
       action='store_true')
   parser.add_argument(
+      '-p', '--phase', help='noto phase (default 3)',
+      metavar='phase', type=int, default=3)
+  parser.add_argument(
       '--outfile', help='write to output file, otherwise to stdout',
       metavar='fname', nargs='?', const='-default-')
   parser.add_argument(
@@ -179,7 +197,8 @@ def main():
     scripts = _check_scripts(args.scripts)
 
   cmapdata = get_cmap_data(
-      scripts, args.unicode_version, args.unicode_only, args.verbose)
+      scripts, args.unicode_version, args.phase, args.unicode_only,
+      args.verbose)
   if args.outfile:
     if args.outfile == '-default-':
       args.outfile = 'lint_cmap_%s.xml' % args.unicode_version

--- a/nototools/noto_data.py
+++ b/nototools/noto_data.py
@@ -441,3 +441,25 @@ CHARACTERS_NOT_NEEDED = {
 ACCEPTABLE_AS_COMBINING = {
     0x02DE,  # MODIFIER LETTER RHOTIC HOOK
 }
+
+
+def get_extra_characters_needed(script, phase):
+  try:
+    if phase == 2:
+      return set(EXTRA_CHARACTERS_NEEDED[script])
+    if phase == 3:
+      return set(P3_EXTRA_CHARACTERS_NEEDED[script])
+  except KeyError:
+    pass
+  return set()
+
+
+def get_characters_not_needed(script, phase):
+  try:
+    if phase == 2:
+      return set(CHARACTERS_NOT_NEEDED[script])
+    if phase == 3:
+      return set(P3_CHARACTERS_NOT_NEEDED[script])
+  except KeyError:
+    pass
+  return set()

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -23,6 +23,7 @@ import sys
 
 from fontTools import ttLib
 
+from nototools import cldr_data
 from nototools import coverage
 from nototools import font_data
 from nototools import lang_data
@@ -65,6 +66,23 @@ def convert_to_four_letter(script_name):
     print >> sys.stderr, 'defaulting script for %s' % script_name
     script_code = script_name
   return script_code
+
+
+def preferred_script_name(script_key):
+  try:
+    return unicode_data.human_readable_script_name(script_key)
+  except:
+    return cldr_data.get_english_script_name(script_key)
+
+
+_script_key_to_report_name = {
+    'Aran': '(Urdu)',
+    'HST': '(Historic)',
+    'LGC': '(LGC)'
+}
+def script_name_for_report(script_key):
+    return (_script_key_to_report_name.get(script_key, None) or
+            preferred_script_name(script_key))
 
 
 # NotoFont maps a font path to information we assume the font to have, based


### PR DESCRIPTION
The version of _get_script_required in lint_cmap_reqs was updated to use
the phased versions of extra script characters that were added to noto_data.
An api was added to cache and get the required chars based on a NotoFont
instance and the noto phase.  Api was added to noto_data to return sets
of required/disallowed characters based on script and phase.  Noto_lint
was then updated to call lint_cmap_reqs to get the characters required
for a font.

To break a circular import, a utility function to return the 'report name'
of a script was moved from noto_lint to noto_fonts.