### PR TITLE
Update cmap_block_coverage to limit scripts, trim output.

### DIFF
--- a/nototools/cmap_block_coverage.py
+++ b/nototools/cmap_block_coverage.py
@@ -261,7 +261,7 @@ def block_coverage(
 
   if summary:
     _summarize_blocks(
-        start, limit, defined_cps, cp_to_scripts, all_scripts, only_scripts)
+        start, limit, defined_cps, cp_to_scripts, all_scripts)
   else:
     _list_blocks(
         start, limit, defined_cps, cp_to_scripts, all_scripts, only_scripts,


### PR DESCRIPTION
Sometimes it's useful to see block coverage only for some scripts.
When you do that, you don't want to see information about all the uncovered
blocks/characters.  This lets you limit the scripts covered and omits the
unwanted information.