### PR TITLE
Disable variant check except for LGC

### DIFF
--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -197,6 +197,12 @@ class FontCondition(object):
       return lhs in rhs
     def test_like(lhs, rhs):
       return rhs.search(lhs) != None
+    def test_is_not(lhs, rhs):
+      return lhs != rhs
+    def test_not_in(lhs, rhs):
+      return lhs not in rhs
+    def test_not_like(lhs, rhs):
+      return rhs.search(lhs) == None
 
     return {
       '<': test_lt,
@@ -207,7 +213,10 @@ class FontCondition(object):
       '>': test_gt,
       'is': test_is,
       'in': test_in,
-      'like': test_like
+      'like': test_like,
+      'is not': test_is_not,
+      'not in': test_not_in,
+      'not like': test_not_like,
       }
 
   fn_map = _init_fn_map()
@@ -250,7 +259,7 @@ class FontCondition(object):
       value = re.compile(value)
     self.__dict__[condition_name] = (fn, value)
 
-  line_re = re.compile(r'([^ \t]+)\s+([^ \t]+)(.*)')
+  line_re = re.compile(r'([^ \t]+)\s+(is not|not like|not in|[^ \t]+)(.*)')
   def modify_line(self, line):
     line = line.strip()
     m = self.line_re.match(line)

--- a/nototools/lint_config.txt
+++ b/nototools/lint_config.txt
@@ -1,7 +1,5 @@
 # we've not checked this before
 disable head/os2/unicoderange
-# this check turns out to be not useful, we only need it in color emoji
-disable cmap/variants
 
 # assume most variant support is based on cmap 14
 disable complex/gsub/variants
@@ -9,6 +7,12 @@ disable complex/gsub/variants
 vendor Monotype
 disable extrema
 
+# most variant tests are not useful.
+# but we do need variant zero in sans/serif LGC
+script is not LGC
+disable cmap/variants
+
+script *
 filename like Avestan
 disable gpos/missing
 


### PR DESCRIPTION
This changes the lint config syntax to allow negating string
conditions, which formerly was not supported.  This provides a simpler
alternative to disabling globally and then selectively enabling.