### PR TITLE
Add additional checks to noto cmap reqs.

### DIFF
--- a/nototools/unicode_data.py
+++ b/nototools/unicode_data.py
@@ -282,6 +282,10 @@ def bidi_mirroring_glyph(char):
         return None
 
 
+def mirrored_chars():
+    return frozenset(_bidi_mirroring_glyph_data.keys())
+
+
 def indic_positional_category(char):
     """Returns the Indic positional category of a character."""
     load_data()


### PR DESCRIPTION
Roozbeh suggested adding a check to ensure that if a bidi mirroring char
is in a font, its mirrored sibling is also in the font.  This adds that
to the cmap generation code.

I'd also noticed that I hadn't explicitly checked the opentype_data
list of special characters.  While this could have been incorporated
into the list of script required characters, it seems more correct to
keep the opentype requirements separate from the others which are mostly
based on unicode data.

As it turns out, this does not impact the resulting cmaps (we were already
covered on both counts) so this commit does not include an update to the
cmap data.

This also add a utility fn to unicode_data to return the set of all
mirrored characters.