### PR TITLE
Load cmap and name data files using full path names.

### DIFF
--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -150,6 +150,8 @@ def get_noto_font(filepath, family_name='Arimo|Cousine|Tinos|Noto'):
   process the path."""
 
   filedir, filename = os.path.split(filepath)
+  if not filedir:
+    filedir = os.getcwd()
   match = match_filename(filename, family_name)
   if match:
     (family, style, mono, script, variant, ui, display, width, weight,

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -364,7 +364,7 @@ def printable_font_versions(font):
 def _build_cmap_dict(filename):
     tooldir = tool_utils.resolve_path('[tools]/nototools')
     data = cmap_data.read_cmap_data_file(
-        path.join(tooldir, filepath))
+        path.join(tooldir, filename))
     script_to_rowdata = cmap_data.create_map_from_table(data.table)
     return {script: frozenset(tool_utils.parse_int_ranges(rd.ranges))
             for script, rd in script_to_rowdata.iteritems()}

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -362,7 +362,9 @@ def printable_font_versions(font):
 
 
 def _build_cmap_dict(filename):
-    data = cmap_data.read_cmap_data_file(filename)
+    tooldir = tool_utils.resolve_path('[tools]/nototools')
+    data = cmap_data.read_cmap_data_file(
+        path.join(tooldir, filepath))
     script_to_rowdata = cmap_data.create_map_from_table(data.table)
     return {script: frozenset(tool_utils.parse_int_ranges(rd.ranges))
             for script, rd in script_to_rowdata.iteritems()}

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -584,7 +584,9 @@ def family_to_name_info_for_phase(phase):
   """Phase is an int, either 2 or 3."""
   result = _PHASE_TO_NAME_INFO_CACHE.get(phase, None)
   if not result and phase in _PHASE_TO_FILENAME:
-    result = read_family_name_info_file(_PHASE_TO_FILENAME[phase])
+    tooldir = tool_utils.resolve_path('[tools]/nototools')
+    result = read_family_name_info_file(
+        path.join(tooldir, _PHASE_TO_FILENAME[phase]))
     _PHASE_TO_NAME_INFO_CACHE[phase] = result
   return result
 


### PR DESCRIPTION
Previously only filenames were used, so loading depended on the user's
current directory.  This should let lint be run from anyplace.