### PR TITLE
Update cmap data tooling to handle 'fallback' codepoints.

### DIFF
--- a/nototools/noto_cmap_reqs.py
+++ b/nototools/noto_cmap_reqs.py
@@ -2642,7 +2642,6 @@ def _get_cmap_data(script_to_chars):
   return cmap_data.CmapData(metadata, tabledata)
 
 
-
 ### debug
 
 def _dump_primaries():


### PR DESCRIPTION
We are suggesting some additional codepoints for fonts based on possible
typographic interaction, and asking MTI to examine whether these additional
codepoints can be omitted from the font and supported via fallback
from the LGC fonts.  We communicate with them using a spreadsheet, when
they have examined a font they mark the font name with an asterisk, and
additionally append an asterisk after each codepoint they feel does not
need to be in the font.

Formerly the tooling did not support this additional data, it only
supported a list of cps for each font.  This makes changes to support an
optional additional list of 'fallback cps'.

cmap_data is modified to read/write 6 columns of data instead of 4, the
two additional columns are the count of 'fallback' code points and the
text representation of these ranges.  When there is no data on fallback
code points, the count is -1.  The data in the two ranges should not
overlap, this however is not verified.

mti_cmap_data is modified to read and write the new data in .csv form,
converting it to the canonical xml form.

compare_cmap_data compares two data files (either of which might or might
not have the additional columns on fallback cps) and reports differences
between them, including differences between the fallback sets, and also
reports on cps that move between standard and fallback sets.

noto_cmap_reqs is modified to merge the computed cmap data (which
does not change) with fallback cmap data from a separate file.

noto_lint does not change, since fallback cps are removed from the standard
cps, noto_lint just sees a smaller set of required cps.