### PR TITLE
Update name table data

### DIFF
--- a/nototools/family_name_info_p2.xml
+++ b/nototools/family_name_info_p2.xml
@@ -1,12 +1,13 @@
 <?xml version='1.0' encoding='utf8'?>
-<family_name_data date="2016-03-11">
+<family_name_data date="2016-04-29">
   <info family="arimo-lgc" omit_regular="t" />
   <info family="cousine-lgc" omit_regular="t" />
   <info family="emoji-zsye" omit_regular="t" />
   <info family="emoji-zsye-color" omit_regular="t" />
   <info family="kufi-arab" omit_regular="t" />
-  <info family="mono-mono" omit_regular="t" use_preferred="t" use_wws="t" />
-  <info family="naskh-arab" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="mono-mono" omit_regular="t" />
+  <info family="naskh-arab" omit_regular="t" />
+  <info family="naskh-arab-ui" omit_regular="t" />
   <info family="nastaliq-aran" omit_regular="t" />
   <info family="sans-armi" omit_regular="t" />
   <info family="sans-armn" omit_regular="t" />
@@ -14,7 +15,8 @@
   <info family="sans-bali" omit_regular="t" />
   <info family="sans-bamu" omit_regular="t" />
   <info family="sans-batk" omit_regular="t" />
-  <info family="sans-beng" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-beng" omit_regular="t" />
+  <info family="sans-beng-ui" omit_regular="t" />
   <info family="sans-brah" omit_regular="t" />
   <info family="sans-bugi" omit_regular="t" />
   <info family="sans-buhd" omit_regular="t" />
@@ -22,53 +24,63 @@
   <info family="sans-cari" omit_regular="t" />
   <info family="sans-cham" omit_regular="t" />
   <info family="sans-cher" omit_regular="t" />
-  <info family="sans-cjk-jp" limit_original="t" />
-  <info family="sans-cjk-kr" limit_original="t" />
-  <info family="sans-cjk-sc" limit_original="t" />
-  <info family="sans-cjk-tc" limit_original="t" />
+  <info family="sans-cjk-jp" no_style_linking="t" />
+  <info family="sans-cjk-kr" no_style_linking="t" />
+  <info family="sans-cjk-sc" no_style_linking="t" />
+  <info family="sans-cjk-tc" no_style_linking="t" />
   <info family="sans-copt" omit_regular="t" />
   <info family="sans-cprt" omit_regular="t" />
-  <info family="sans-deva" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-deva" omit_regular="t" />
+  <info family="sans-deva-ui" omit_regular="t" />
   <info family="sans-dsrt" omit_regular="t" />
   <info family="sans-egyp" omit_regular="t" />
   <info family="sans-ethi" omit_regular="t" />
   <info family="sans-geor" omit_regular="t" />
   <info family="sans-glag" omit_regular="t" />
   <info family="sans-goth" omit_regular="t" />
-  <info family="sans-gujr" omit_regular="t" use_preferred="t" use_wws="t" />
-  <info family="sans-guru" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-gujr" omit_regular="t" />
+  <info family="sans-gujr-ui" omit_regular="t" />
+  <info family="sans-guru" omit_regular="t" />
+  <info family="sans-guru-ui" omit_regular="t" />
   <info family="sans-hano" omit_regular="t" />
-  <info family="sans-hans" limit_original="t" />
-  <info family="sans-hant" limit_original="t" />
+  <info family="sans-hans" no_style_linking="t" />
+  <info family="sans-hant" no_style_linking="t" />
   <info family="sans-hebr" omit_regular="t" />
   <info family="sans-ital" omit_regular="t" />
   <info family="sans-java" omit_regular="t" />
-  <info family="sans-jpan" limit_original="t" />
+  <info family="sans-jpan" no_style_linking="t" />
   <info family="sans-kali" omit_regular="t" />
   <info family="sans-khar" omit_regular="t" />
-  <info family="sans-khmr" omit_regular="t" use_preferred="t" use_wws="t" />
-  <info family="sans-knda" omit_regular="t" use_preferred="t" use_wws="t" />
-  <info family="sans-kore" limit_original="t" />
+  <info family="sans-khmr" omit_regular="t" />
+  <info family="sans-khmr-ui" omit_regular="t" />
+  <info family="sans-knda" omit_regular="t" />
+  <info family="sans-knda-ui" omit_regular="t" />
+  <info family="sans-kore" no_style_linking="t" />
   <info family="sans-kthi" omit_regular="t" />
   <info family="sans-lana" omit_regular="t" />
-  <info family="sans-laoo" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-laoo" omit_regular="t" />
+  <info family="sans-laoo-ui" omit_regular="t" />
   <info family="sans-lepc" omit_regular="t" />
-  <info family="sans-lgc" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-lgc" omit_regular="t" />
+  <info family="sans-lgc-ui" omit_regular="t" />
   <info family="sans-limb" omit_regular="t" />
   <info family="sans-linb" omit_regular="t" />
   <info family="sans-lisu" omit_regular="t" />
   <info family="sans-lyci" omit_regular="t" />
   <info family="sans-lydi" omit_regular="t" />
   <info family="sans-mand" omit_regular="t" />
-  <info family="sans-mlym" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-mlym" omit_regular="t" />
+  <info family="sans-mlym-ui" omit_regular="t" />
   <info family="sans-mong" omit_regular="t" />
   <info family="sans-mtei" omit_regular="t" />
-  <info family="sans-mymr" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-mymr" omit_regular="t" />
+  <info family="sans-mymr-ui" omit_regular="t" />
   <info family="sans-nkoo" omit_regular="t" />
   <info family="sans-ogam" omit_regular="t" />
   <info family="sans-olck" omit_regular="t" />
   <info family="sans-orkh" omit_regular="t" />
-  <info family="sans-orya" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-orya" omit_regular="t" />
+  <info family="sans-orya-ui" omit_regular="t" />
   <info family="sans-osma" omit_regular="t" />
   <info family="sans-phag" omit_regular="t" />
   <info family="sans-phli" omit_regular="t" />
@@ -89,13 +101,16 @@
   <info family="sans-tagb" omit_regular="t" />
   <info family="sans-tale" omit_regular="t" />
   <info family="sans-talu" omit_regular="t" />
-  <info family="sans-taml" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-taml" omit_regular="t" />
+  <info family="sans-taml-ui" omit_regular="t" />
   <info family="sans-tavt" omit_regular="t" />
-  <info family="sans-telu" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-telu" omit_regular="t" />
+  <info family="sans-telu-ui" omit_regular="t" />
   <info family="sans-tfng" omit_regular="t" />
   <info family="sans-tglg" omit_regular="t" />
   <info family="sans-thaa" omit_regular="t" />
-  <info family="sans-thai" omit_regular="t" use_preferred="t" use_wws="t" />
+  <info family="sans-thai" omit_regular="t" />
+  <info family="sans-thai-ui" omit_regular="t" />
   <info family="sans-tibt" omit_regular="t" />
   <info family="sans-ugar" omit_regular="t" />
   <info family="sans-vaii" omit_regular="t" />

--- a/nototools/family_name_info_p3.xml
+++ b/nototools/family_name_info_p3.xml
@@ -8,7 +8,7 @@
   <info family="mono-mono" use_preferred="t" use_wws="t" />
   <info family="naskh-arab" use_preferred="t" use_wws="t" />
   <info family="nastaliq-aran" />
-  <info family="sans-arab" limit_original="t" />
+  <info family="sans-arab" use_preferred="t"/>
   <info family="sans-armi" />
   <info family="sans-armn" limit_original="t" use_wws="t" />
   <info family="sans-avst" />

--- a/nototools/family_name_info_p3.xml
+++ b/nototools/family_name_info_p3.xml
@@ -1,21 +1,23 @@
 <?xml version='1.0' encoding='utf8'?>
-<family_name_data date="2016-04-12">
+<family_name_data date="2016-04-29">
   <info family="arimo-lgc" />
   <info family="cousine-lgc" />
   <info family="emoji-zsye" />
   <info family="emoji-zsye-color" />
   <info family="kufi-arab" />
-  <info family="mono-mono" use_preferred="t" use_wws="t" />
-  <info family="naskh-arab" use_preferred="t" use_wws="t" />
+  <info family="mono-mono" />
+  <info family="naskh-arab" />
+  <info family="naskh-arab-ui" />
   <info family="nastaliq-aran" />
-  <info family="sans-arab" use_preferred="t"/>
+  <info family="sans-arab" family_name_style="short" use_preferred="t" />
   <info family="sans-armi" />
-  <info family="sans-armn" limit_original="t" use_wws="t" />
+  <info family="sans-armn" family_name_style="very short" use_preferred="t" />
   <info family="sans-avst" />
   <info family="sans-bali" />
   <info family="sans-bamu" />
   <info family="sans-batk" />
-  <info family="sans-beng" use_preferred="t" use_wws="t" />
+  <info family="sans-beng" />
+  <info family="sans-beng-ui" />
   <info family="sans-brah" />
   <info family="sans-bugi" />
   <info family="sans-buhd" />
@@ -23,59 +25,70 @@
   <info family="sans-cari" />
   <info family="sans-cham" />
   <info family="sans-cher" />
-  <info family="sans-cjk-jp" limit_original="t" />
-  <info family="sans-cjk-kr" limit_original="t" />
-  <info family="sans-cjk-sc" limit_original="t" />
-  <info family="sans-cjk-tc" limit_original="t" />
+  <info family="sans-cjk-jp" use_preferred="t" />
+  <info family="sans-cjk-kr" use_preferred="t" />
+  <info family="sans-cjk-sc" use_preferred="t" />
+  <info family="sans-cjk-tc" use_preferred="t" />
   <info family="sans-copt" />
   <info family="sans-cprt" />
-  <info family="sans-deva" limit_original="t" use_wws="t" />
+  <info family="sans-deva" family_name_style="short" use_preferred="t" />
+  <info family="sans-deva-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-dsrt" />
   <info family="sans-egyp" />
   <info family="sans-ethi" />
-  <info family="sans-geor" limit_original="t" use_wws="t" />
+  <info family="sans-geor" family_name_style="very short" use_preferred="t" />
   <info family="sans-glag" />
   <info family="sans-goth" />
-  <info family="sans-gujr" use_preferred="t" use_wws="t" />
-  <info family="sans-guru" use_preferred="t" use_wws="t" />
+  <info family="sans-gujr" />
+  <info family="sans-gujr-ui" />
+  <info family="sans-guru" />
+  <info family="sans-guru-ui" />
   <info family="sans-hano" />
-  <info family="sans-hans" limit_original="t" />
-  <info family="sans-hant" limit_original="t" />
-  <info family="sans-hebr" limit_original="t" use_wws="t" />
+  <info family="sans-hans" use_preferred="t" />
+  <info family="sans-hant" use_preferred="t" />
+  <info family="sans-hebr" family_name_style="short" use_preferred="t" />
   <info family="sans-ital" />
   <info family="sans-java" />
-  <info family="sans-jpan" limit_original="t" />
+  <info family="sans-jpan" use_preferred="t" />
   <info family="sans-kali" />
   <info family="sans-khar" />
-  <info family="sans-khmr" use_preferred="t" use_wws="t" />
-  <info family="sans-knda" use_preferred="t" use_wws="t" />
-  <info family="sans-kore" limit_original="t" />
+  <info family="sans-khmr" />
+  <info family="sans-khmr-ui" />
+  <info family="sans-knda" />
+  <info family="sans-knda-ui" />
+  <info family="sans-kore" use_preferred="t" />
   <info family="sans-kthi" />
   <info family="sans-lana" />
-  <info family="sans-laoo" use_preferred="t" use_wws="t" />
+  <info family="sans-laoo" />
+  <info family="sans-laoo-ui" />
   <info family="sans-lepc" />
-  <info family="sans-lgc" limit_original="t" use_wws="t" />
+  <info family="sans-lgc" />
+  <info family="sans-lgc-display" family_name_style="short" use_preferred="t" />
+  <info family="sans-lgc-ui" family_name_style="short" use_preferred="t" />
   <info family="sans-limb" />
   <info family="sans-linb" />
   <info family="sans-lisu" />
   <info family="sans-lyci" />
   <info family="sans-lydi" />
   <info family="sans-mand" />
-  <info family="sans-mlym" use_preferred="t" use_wws="t" />
+  <info family="sans-mlym" />
+  <info family="sans-mlym-ui" />
   <info family="sans-mong" />
-  <info family="sans-mono-mono" limit_original="t" use_wws="t" />
+  <info family="sans-mono-mono" family_name_style="short" use_preferred="t" />
   <info family="sans-mtei" />
-  <info family="sans-mymr" use_preferred="t" use_wws="t" />
+  <info family="sans-mymr" />
+  <info family="sans-mymr-ui" />
   <info family="sans-nkoo" />
   <info family="sans-ogam" />
   <info family="sans-olck" />
   <info family="sans-orkh" />
-  <info family="sans-orya" use_preferred="t" use_wws="t" />
+  <info family="sans-orya" />
+  <info family="sans-orya-ui" />
   <info family="sans-osma" />
   <info family="sans-phag" />
   <info family="sans-phli" />
   <info family="sans-phnx" />
-  <info family="sans-prti" />
+  <info family="sans-prti" family_name_style="extra short" />
   <info family="sans-rjng" />
   <info family="sans-runr" />
   <info family="sans-samr" />
@@ -91,13 +104,16 @@
   <info family="sans-tagb" />
   <info family="sans-tale" />
   <info family="sans-talu" />
-  <info family="sans-taml" use_preferred="t" use_wws="t" />
+  <info family="sans-taml" />
+  <info family="sans-taml-ui" />
   <info family="sans-tavt" />
-  <info family="sans-telu" use_preferred="t" use_wws="t" />
+  <info family="sans-telu" />
+  <info family="sans-telu-ui" />
   <info family="sans-tfng" />
   <info family="sans-tglg" />
   <info family="sans-thaa" />
-  <info family="sans-thai" limit_original="t" use_wws="t" />
+  <info family="sans-thai" use_preferred="t" />
+  <info family="sans-thai-ui" />
   <info family="sans-tibt" />
   <info family="sans-ugar" />
   <info family="sans-vaii" />
@@ -105,18 +121,18 @@
   <info family="sans-xsux" />
   <info family="sans-yiii" />
   <info family="sans-zsym" />
-  <info family="serif-armn" limit_original="t" use_wws="t" />
+  <info family="serif-armn" />
   <info family="serif-beng" />
-  <info family="serif-geor" limit_original="t" use_wws="t" />
+  <info family="serif-geor" family_name_style="very short" use_preferred="t" />
   <info family="serif-gujr" />
-  <info family="serif-hebr" limit_original="t" use_wws="t" />
   <info family="serif-khmr" />
   <info family="serif-knda" />
   <info family="serif-laoo" />
-  <info family="serif-lgc" limit_original="t" use_wws="t" />
+  <info family="serif-lgc" family_name_style="short" use_preferred="t" />
+  <info family="serif-lgc-display" family_name_style="short" use_preferred="t" />
   <info family="serif-mlym" />
   <info family="serif-taml" />
   <info family="serif-telu" />
-  <info family="serif-thai" limit_original="t" />
+  <info family="serif-thai" use_preferred="t" />
   <info family="tinos-lgc" />
 </family_name_data>

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -140,8 +140,7 @@ _FONT_NAME_REGEX = (
     '(UI)?'
     '(Display)?'
     '-?'
-    '((?:Semi|Extra|)Cond(?:ensed)?|Narrow)?'
-    '-?' +  # at the moment, allow either naming
+    '((?:Semi)?Condensed)?'
     '(|%s)?' % '|'.join(WEIGHTS.keys()) +
     '(Italic)?'
     '\.(ttf|ttc|otf)')
@@ -311,6 +310,22 @@ def noto_font_to_family_id(notofont):
     tags.append(notofont.variant)
   key = '-'.join(tags)
   return key.lower()
+
+
+def noto_font_to_wws_family_id(notofont):
+  """Return an id roughly corresponding to the wws family.  Used to identify
+  naming rules for the corresponding fonts. Compare to noto_font_to_family_id,
+  which corresponds to a preferred family and is used to determine the language
+  support for those fonts.  For example, 'Noto Sans Devanagari UI' and
+  'Noto Sans Devanagari' support the same languages (e.g. have the same cmap)
+  but have different wws family names and different name rules (names for the
+  UI variant use very short abbreviations)."""
+  id = noto_font_to_family_id(notofont)
+  if notofont.is_UI:
+    id += '-ui'
+  if notofont.is_display:
+    id += '-display'
+  return id
 
 
 def get_noto_fonts(paths=NOTO_FONT_PATHS):

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -421,8 +421,8 @@ FontProps = collections.namedtuple(
     'is_cjk, subset')
 
 
-def font_properties_from_name(file_path):
-    noto_font = noto_fonts.get_noto_font(file_path)
+def font_properties_from_name(file_path, phase):
+    noto_font = noto_fonts.get_noto_font(file_path, phase=phase)
     if not noto_font:
         return None
 
@@ -435,8 +435,8 @@ def font_properties_from_name(file_path):
     return FontProps(is_google, vendor, char_version, *noto_font)
 
 
-def get_font_properties_with_fallback(file_path):
-    props = font_properties_from_name(file_path)
+def get_font_properties_with_fallback(file_path, phase):
+    props = font_properties_from_name(file_path, phase)
     if props:
         return props, '' if props.script else 'script'
 
@@ -638,7 +638,8 @@ def check_font(font_props, filename_error,
 
         family_to_name_info = noto_names.family_to_name_info_for_phase(
             noto_phase)
-        name_data = noto_names.name_table_data(noto_font, family_to_name_info)
+        name_data = noto_names.name_table_data(
+            noto_font, family_to_name_info, noto_phase)
         if not name_data:
             warn("name/unable_to_check", "Unable to check",
                  "No name data available for this font.")
@@ -2011,7 +2012,8 @@ def main():
 
     if arguments.dump_font_props:
         for font_file_path in arguments.font_files:
-            font_props, filename_error = get_font_properties_with_fallback(font_file_path)
+            font_props, filename_error = get_font_properties_with_fallback(
+                font_file_path, phase=arguments.phase)
             if filename_error:
                 print '#Error for %s: %s' % (font_file_path, filename_error)
             else:
@@ -2025,7 +2027,8 @@ def main():
               "Hint Status,File Name,Revision,Issue")
 
     for font_file_path in arguments.font_files:
-        font_props, filename_error = get_font_properties_with_fallback(font_file_path)
+        font_props, filename_error = get_font_properties_with_fallback(
+            font_file_path, phase=arguments.phase)
         if not font_props:
             print '## ERROR: cannot parse %s' % font_file_path
         else:

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -27,10 +27,8 @@ version of this data.
 
 The other set of routines generates name information for a noto font,
 using the family name info.  The family name info is required.  For
-example, familes whose subfamilies have more weights than regular/bold
-will have limit_original set, and so will not include the weight in the
-original subfamily name, even if a particular font instance (not knowing
-about the structure of the entire family) could.
+example, familes that have no_style_linking set will put Bold and Regular
+in the original family name and not the subfamily.
 
 The tool api lets you generate the family info file, and/or use it to
 show how one or more fonts' names would be generated.
@@ -86,23 +84,29 @@ FAMILY_NAME_INFO_FILE='family_name_info.xml'
 PHASE_2_FAMILY_NAME_INFO_FILE = 'family_name_info_p2.xml'
 PHASE_3_FAMILY_NAME_INFO_FILE = 'family_name_info_p3.xml'
 
-# Represents what and how we write family names in the name table.
-# If limit_original is true, weights become part of the family name,
-# otherwise the family only has Bold and Regular weights so they
-# remain in the subfamily.
-# if use_preferred is true, there are subfamilies that don't fit into
+# Represents how we write family names in the name table.
+#
+# If no_style_linking is true, 'Bold' and 'Regular' weights become
+# part of the family name and the subfamily is 'Regular' or 'Italic',
+# otherwise 'Bold' and 'Regular' are not in the family name and
+# go into the subfamily ('Regular' does not if 'Italic' is there).
+# no_style_linking should not be set if there are no extra weights
+# or widths.
+#
+# If use_preferred is true, there are subfamilies that don't fit into
 # Regular Bold BoldItalic Italic, so generate the preferred names.
 # Preferred names are actually WWS names, non-wws fields are promoted
-# to the preferred family and WWS name fields are never populated.
-# if omit_regular is true, postscript names exclude the subfamily
+# to the family and WWS name fields are never populated.
+#
+# If omit_regular is true, postscript and full names exclude the subfamily
 # when it is 'Regular' (Noto phase 2 non-CJK behavior).
 FamilyNameInfo = collections.namedtuple(
     'FamilyNameInfo',
-    'limit_original, use_preferred, omit_regular')
+    'no_style_linking, use_preferred, omit_regular, family_name_style')
 
 # Represents expected name table data for a font.
 # Fields expected to be empty are None.  Fields that are expected
-# to be present but have any value are '-'.
+# to be present but can have any value are '-'.
 NameTableData = collections.namedtuple(
     'NameTableData',
     'copyright_re, original_family, original_subfamily, unique_id, '
@@ -255,15 +259,79 @@ def _is_limited_original_part(part):
   return _LIMITED_ORIGINAL_RE.match(part)
 
 
-def _original_parts(family_parts, subfamily_parts, limited=False):
-  """Set limited to true if weight should be in the family and not
+def _original_parts(family_parts, subfamily_parts, no_style_linking=False):
+  """Set no_style_linking to true if weight should be in the family and not
   the subfamily."""
-  stop_fn = _is_limited_original_part if limited else _is_original_part
+  stop_fn = _is_limited_original_part if no_style_linking else _is_original_part
   return _shift_parts(family_parts, subfamily_parts, stop_fn)
 
 
-def _names(family_parts, subfamily_parts):
-  return (' '.join(family_parts), ' '.join(subfamily_parts))
+_SHORT_NAMES = {
+    'Condensed': 'Cond',
+    'SemiCondensed': 'SemCond',
+    'SemiLight': 'SemLt',
+    'Medium': 'Med',
+    'SemiBold': 'SemBd',
+    'ExtraBold': 'ExtBd',
+    'Black': 'Blk',
+    'Display': 'Disp',
+}
+
+_VERY_SHORT_NAMES = {
+    'Condensed': 'Cn',
+    'SemiCondensed': 'SmCn',
+    'Thin': 'Th',
+    'Light': 'Lt',
+    'SemiLight': 'SmLt',
+    'Medium': 'Md',
+    'Bold': 'Bd',
+    'SemiBold': 'SmBd',
+    'ExtraBold': 'XBd',
+    'Black': 'Bk',
+    'Display': 'D',
+}
+
+
+# TODO: consider shortening the script name as well
+
+def _name_style_for_length(parts, limit):
+  """Return a value indicating whether to use normal, short, very short, or
+  extra short names to represent these parts, depending on what is
+  required to ensure the length <= limit."""
+
+  if limit == 0:
+    return 'normal'
+  name = ' '.join(parts)
+  if len(name) <= limit:
+    return 'normal'
+  name = ' '.join(_SHORT_NAMES.get(n, n) for n in parts)
+  if len(name) <= limit:
+    return 'short'
+  name = ' '.join(_VERY_SHORT_NAMES.get(n, n) for n in parts)
+  if len(name) <= limit:
+    return 'very short'
+  name = name.replace(' ', '')
+  if len(name) <= limit:
+    return 'extra short'
+  raise ValueError('cannot fit %s to length %d' % (parts, limit))
+
+
+def _name_with_style(parts, name_style):
+  """Return a name from parts, using the limit key to determine the style."""
+  if name_style == 'normal':
+    return ' '.join(parts)
+  if name_style == 'short':
+    return ' '.join(_SHORT_NAMES.get(n, n) for n in parts)
+  name = ' '.join(_VERY_SHORT_NAMES.get(n, n) for n in parts)
+  if name_style != 'very short':  # 'extra short'
+    name = name.replace(' ', '')
+  return name
+
+
+def _names(family_parts, subfamily_parts, family_name_style='normal'):
+  family = _name_with_style(family_parts, family_name_style)
+  subfamily = ' '.join(subfamily_parts)
+  return family, subfamily
 
 
 def _preferred_names(preferred_family, preferred_subfamily, use_preferred):
@@ -273,9 +341,12 @@ def _preferred_names(preferred_family, preferred_subfamily, use_preferred):
   return None, None
 
 
-def _original_names(preferred_family, preferred_subfamily, limited):
+def _original_names(
+    preferred_family, preferred_subfamily, no_style_linking,
+    family_name_style):
   return _names(*_original_parts(
-      preferred_family, preferred_subfamily, limited=limited))
+      preferred_family, preferred_subfamily, no_style_linking=no_style_linking),
+                family_name_style=family_name_style)
 
 
 def _copyright_re(noto_font):
@@ -430,14 +501,14 @@ def _license_url(noto_font):
 
 def name_table_data(noto_font, family_to_name_info, phase):
   """Returns a NameTableData for this font given the family_to_name_info."""
-  family_id = noto_fonts.noto_font_to_family_id(noto_font)
+  family_id = noto_fonts.noto_font_to_wws_family_id(noto_font)
   try:
     info = family_to_name_info[family_id]
   except KeyError:
     print >> sys.stderr, 'no family name info for "%s"' % family_id
     return None
 
-  family_parts, subfamily_parts = _preferred_parts(noto_font)
+  family_parts, subfamily_parts = _wws_parts(*_preferred_parts(noto_font))
   if not info.use_preferred and subfamily_parts not in [
       ['Regular'],
       ['Bold'],
@@ -450,7 +521,8 @@ def name_table_data(noto_font, family_to_name_info, phase):
     return None
 
   ofn, osfn = _original_names(
-      family_parts, subfamily_parts, info.limit_original)
+      family_parts, subfamily_parts, info.no_style_linking,
+      info.family_name_style)
   # If we limit the original names (to put weights into the original family)
   # then we need a preferred name to undo this.  When info is read or generated,
   # the code should ensure use_preferred is set.
@@ -485,10 +557,11 @@ def name_table_data(noto_font, family_to_name_info, phase):
 
 
 def _create_family_to_subfamilies(notofonts):
-  """Return a map from preferred family name to set of preferred subfamilies."""
+  """Return a map from preferred family name to set of preferred subfamilies.
+  Note these are WWS family/subfamilies now."""
   family_to_subfamilies = collections.defaultdict(set)
   for noto_font in notofonts:
-    family, subfamily = _names(*_preferred_parts(noto_font))
+    family, subfamily = _names(*_wws_parts(*_preferred_parts(noto_font)))
     family_to_subfamilies[family].add(subfamily)
   return family_to_subfamilies
 
@@ -501,13 +574,28 @@ _WWS_PARTS = frozenset(
     ['SemiCondensed', 'Condensed', 'Italic'] +
     list(noto_fonts.WEIGHTS))
 
+
+def _select_name_style(styles):
+  for style in ['extra short', 'very short', 'short']:
+    if style in styles:
+      return style
+  return 'normal'
+
+
 def create_family_to_name_info(notofonts, phase):
   family_to_parts = collections.defaultdict(set)
+  family_to_name_styles = collections.defaultdict(set)
   cjk_families = set()
   for noto_font in notofonts:
-    family_id = noto_fonts.noto_font_to_family_id(noto_font)
-    family_parts, subfamily_parts = _preferred_parts(noto_font)
+    family_id = noto_fonts.noto_font_to_wws_family_id(noto_font)
+    preferred_family, preferred_subfamily = _preferred_parts(noto_font)
+    _, subfamily_parts = _wws_parts(preferred_family, preferred_subfamily)
     family_to_parts[family_id].update(subfamily_parts)
+    # It's been asserted that the family name can't be longer than 32 chars.
+    # Assume this is only true for nameID 1 and not nameID 16 or 17.
+    family_parts, _ = _original_parts(preferred_family, preferred_subfamily)
+    family_name_style = _name_style_for_length(family_parts, 31)
+    family_to_name_styles[family_id].add(family_name_style)
     if noto_font.is_cjk:
       cjk_families.add(family_id)
   result = {}
@@ -516,25 +604,30 @@ def create_family_to_name_info(notofonts, phase):
     # bold and regular weights, they behave like they have more weights like
     # the rest of CJK.
     family_is_cjk = family_id in cjk_families
-    limit_original = family_is_cjk or bool(
-        part_set & _NON_ORIGINAL_WEIGHT_PARTS)
-    # If we limit original, then we automatically use_preferred.
-    use_preferred = limit_original or bool(part_set - _WWS_PARTS)
-    # In phase 3, we keep 'Regular' in the postscript name always, prior to that
-    # we only do so for CJK.
+    no_style_linking = phase == 2 and family_is_cjk
+    use_preferred = no_style_linking or bool(part_set - _ORIGINAL_PARTS)
+    # In phase 3, we keep 'Regular' in the postscript/full name always, prior to
+    # that we only do so for CJK.
     omit_regular = phase == 2 and not family_is_cjk
+    name_style = 'normal' if phase == 2 else _select_name_style(
+        family_to_name_styles[family_id])
     result[family_id] = FamilyNameInfo(
-        limit_original, use_preferred, omit_regular)
+        no_style_linking, use_preferred, omit_regular, name_style)
   return result
 
 
 def _build_info_element(family, info):
   attrs = {'family': family}
   for attr in FamilyNameInfo._fields:
-    if getattr(info, attr):
+    val = getattr(info, attr)
+    if attr == 'family_name_style':
+      # only write family length style if not 'normal'
+      if val != 'normal':
+        attrs[attr] = val
+    elif val:
       attrs[attr] = 't'
-  # Don't have to write it out since limit_original implies use_preferred
-  if 'limit_original' in attrs and 'use_preferred' in attrs:
+  # Don't have to write it out since no_style_linking implies use_preferred
+  if 'no_style_linking' in attrs and 'use_preferred' in attrs:
     del attrs['use_preferred']
   return ET.Element('info', attrs)
 
@@ -554,11 +647,14 @@ def _build_tree(family_to_name_info, pretty=False):
 def _read_info_element(info_node):
   def bval(attr):
     return bool(info_node.get(attr, False))
-  # limit_original implies use_preferred
+  def nval(attr):
+    return info_node.get(attr, 'normal')
+  # no_style_linking implies use_preferred
   return FamilyNameInfo(
-      bval('limit_original'),
-      bval('limit_original') or bval('use_preferred') or bval('use_wws'),
-      bval('omit_regular'))
+      bval('no_style_linking'),
+      bval('no_style_linking') or bval('use_preferred') or bval('use_wws'),
+      bval('omit_regular'),
+      nval('family_name_style'))
 
 
 def _read_tree(root):
@@ -630,26 +726,37 @@ def _dump_family_to_faces(family_to_faces):
 def _dump_name_data(name_data):
   if not name_data:
     print '  Error: no name data'
-    return
+    return True
+
+  err = False
   for attr in NameTableData._fields:
     value = getattr(name_data, attr)
     if value:
+      if attr == 'original_family' and len(value) > 31:
+        print '## family too long'
+        err = True
       print '  %20s: %s' % (attr, value)
     else:
       print '  %20s: <none>' % attr
+  return err
 
 
-def _dump_family_names(notofonts, family_to_name_info):
+def _dump_family_names(notofonts, family_to_name_info, phase):
+  err_names = []
   for font in sorted(notofonts, key=lambda f: f.filepath):
-    name_data = name_table_data(font, family_to_name_info)
+    name_data = name_table_data(font, family_to_name_info, phase)
     print font.filepath
-    _dump_name_data(name_data)
+    if _dump_name_data(name_data):
+      err_names.append(font.filepath)
+  if err_names:
+    print '%d names too long:\n  %s' % (
+        len(err_names), '\n  '.join(err_names))
 
 
-def _dump(fonts, info_file):
+def _dump(fonts, info_file, phase):
   """Display information about fonts, using name info from info_file."""
   family_to_name_info = read_family_name_info_file(info_file)
-  _dump_family_names(fonts, family_to_name_info)
+  _dump_family_names(fonts, family_to_name_info, phase)
 
 
 def _write(fonts, info_file, phase):
@@ -662,11 +769,11 @@ def _write(fonts, info_file, phase):
     print write_family_name_info(family_to_name_info, pretty=True)
 
 
-def _test(fonts):
+def _test(fonts, phase):
   """Build name info from font_paths and dump the names for them."""
-  family_to_name_info = create_family_to_name_info(fonts)
+  family_to_name_info = create_family_to_name_info(fonts, phase)
   print write_family_name_info(family_to_name_info, pretty=True)
-  _dump_family_names(fonts, family_to_name_info)
+  _dump_family_names(fonts, family_to_name_info, phase)
 
 
 def _info(fonts):
@@ -763,7 +870,7 @@ def main():
       return
     _write(fonts, args.info_file, args.phase)
   elif args.cmd == 'test':
-    _test(fonts)
+    _test(fonts, args.phase)
   elif args.cmd == 'info':
     _info(fonts)
 


### PR DESCRIPTION
The main changes are to implement 'style linking' by default for phase 3 fonts, use wws style naming for the preferred names and omit wws names, and use abbreviated versions of nameID 1 names where necessary.