### PR TITLE
Lint namedata update

### DIFF
--- a/nototools/check_familyname_and_styles.py
+++ b/nototools/check_familyname_and_styles.py
@@ -1,0 +1,174 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process a family description file.
+
+You can check the file, and generate a list of font file names from it.
+This list can be passed to noto_names to generate the name data.
+
+The file is a list of Noto family names (see noto_fonts.py) interspersed with
+definitions of what WWS style combinations apply to that file.  See
+_get_stylenames() for the format.  Each style definition applies to each
+following family until the next style definition."""
+
+import argparse
+import re
+
+from nototools import noto_fonts
+
+_style_re = re.compile(r'--\s+(.*)\s+--')
+_extended_style_re = re.compile(r'^([TRBH]+)(?:/([CR]+)(?:/([RI]+))?)?$')
+
+# Below we use the longest names we intend, so that the noto_names code can
+# identify which families need extra short abbreviations.  The style of
+# abbreviation is based on the longest names in the family.
+
+_WEIGHT_NAMES = {
+    'T': 'Thin',
+    'R': 'Regular',
+    'B': 'Bold',
+    'H': 'ExtraBold' # Nee 'Heavy'. Not 'Black' because 'ExtraBold' is longer.
+}
+
+_WIDTH_NAMES = {
+    'C': 'SemiCondensed', # We use this since it is longer. We don't expect to
+                          # use ExtraCondensed.
+    'R': ''
+}
+
+_ITALIC_NAMES = {
+    'I': 'Italic',
+    'R': '',
+}
+
+def _get_stylenames(styles):
+  """Returns the list of style names for the encoded styles.  These are the
+  (master-ish) style names encoded as weights / widths/ italic, where weights
+  is any of 'T', 'R', 'B', or 'H', widths any of 'C' or 'R', and italic 'I'.
+  If there's not an italic then the italic is omitted, if there's only
+  regular width and no italic then widths are omitted."""
+  m = _extended_style_re.match(styles)
+  assert m
+  weights = m.group(1)
+  widths = m.group(2) or 'R'
+  slopes = m.group(3) or 'R'
+  # print '%s: %s, %s, %s' % (styles, weights, widths, slopes)
+  names = []
+  for wd in widths:
+    width_name = _WIDTH_NAMES[wd]
+    for wt in weights:
+      weight_name = _WEIGHT_NAMES[wt]
+      for it in slopes:
+        italic_name = _ITALIC_NAMES[it]
+        final_weight_name = weight_name
+        if wt == 'R' and (width_name or italic_name):
+          final_weight_name = ''
+        names.append(width_name + final_weight_name + italic_name)
+  return names
+
+
+def check_familyname(name, styles):
+  notofont = noto_fonts.get_noto_font('unhinted/' + name + '-Regular.ttf')
+  if not notofont:
+    print 'Error: could not parse', name
+    return False
+  print name, noto_fonts.noto_font_to_wws_family_id(notofont), styles
+  return True
+
+
+def generate_family_filenames(name, styles):
+  """Name is the family name portion of a Noto filename.  Styles is the
+  encoding of the styles, see _get_stylenames."""
+  stylenames = _get_stylenames(styles)
+  return [name + '-' + s + '.ttf' for s in stylenames]
+
+
+def _for_all_familynames(namefile, fn):
+  """Call fn passing the family name and style descriptor for
+  all families in namefile. '#' is a comment to eol, blank lines are
+  ignored."""
+  styles = 'RB'
+  with open(namefile, 'r') as f:
+    for name in f:
+      ix = name.find('#')
+      if ix >= 0:
+        name = name[:ix]
+      name = name.strip()
+      if not name:
+        continue
+
+      m = _style_re.match(name)
+      if m:
+        styles = m.group(1)
+        continue
+      assert name[0] != '-'
+      fn(name, styles)
+
+
+def check_familynames(namefile):
+  passed = [True]
+  def fn(namefile, styles):
+    name_passed = check_familyname(namefile, styles)
+    passed[0] &= name_passed
+  _for_all_familynames(namefile, fn)
+  return passed[0]
+
+
+def generate_filenames(namefile, outfile):
+  namelist = []
+  def fn(name, styles):
+    namelist.extend(generate_family_filenames(name, styles))
+  _for_all_familynames(namefile, fn)
+  allnames = '\n'.join(namelist)
+  if outfile:
+    with open(outfile, 'w') as f:
+      f.write(allnames)
+      f.write('\n')
+  else:
+    print allnames
+
+
+def main():
+  DEFAULT_NAMEDATA = 'familyname_and_styles.txt'
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-f', '--familynamedata', help='file containing family name/style data'
+      ' (default %s)' % DEFAULT_NAMEDATA, metavar='file',
+      default=DEFAULT_NAMEDATA)
+  parser.add_argument(
+      '-c', '--check', help='check family name/style data', action='store_true')
+  parser.add_argument(
+      '-w', '--write', help='write filenames, default stdout', nargs='?',
+      const='stdout', metavar='file')
+  args = parser.parse_args()
+
+  if args.check:
+    passed = check_familynames(args.familynamedata)
+    if not passed:
+      print 'Check failed, some files had errors.'
+      return
+    print 'Check succeeded.'
+
+  if args.write:
+    outfile = None if args.write == 'stdout' else args.write
+    if not outfile and args.check:
+      print
+    generate_filenames(args.familynamedata, outfile)
+    if outfile:
+      print 'Wrote', outfile
+
+
+if __name__ == '__main__':
+  main()

--- a/nototools/check_familyname_and_styles.py
+++ b/nototools/check_familyname_and_styles.py
@@ -63,7 +63,7 @@ def _get_stylenames(styles):
   weights = m.group(1)
   widths = m.group(2) or 'R'
   slopes = m.group(3) or 'R'
-  # print '%s: %s, %s, %s' % (styles, weights, widths, slopes)
+
   names = []
   for wd in widths:
     width_name = _WIDTH_NAMES[wd]
@@ -98,7 +98,7 @@ def _for_all_familynames(namefile, fn):
   """Call fn passing the family name and style descriptor for
   all families in namefile. '#' is a comment to eol, blank lines are
   ignored."""
-  styles = 'RB'
+  styles = None
   with open(namefile, 'r') as f:
     for name in f:
       ix = name.find('#')
@@ -112,14 +112,21 @@ def _for_all_familynames(namefile, fn):
       if m:
         styles = m.group(1)
         continue
-      assert name[0] != '-'
+
+      # Catch a common error in which an intended style tag didn't match the
+      # regex.
+      if name[0] == '-':
+        raise ValueError('Looks like a bad style tag: "%s"' % name)
+      if styles == None:
+        raise ValueError('Styles must be set before first familyname.')
+
       fn(name, styles)
 
 
 def check_familynames(namefile):
   passed = [True]
-  def fn(namefile, styles):
-    name_passed = check_familyname(namefile, styles)
+  def fn(name, styles):
+    name_passed = check_familyname(name, styles)
     passed[0] &= name_passed
   _for_all_familynames(namefile, fn)
   return passed[0]

--- a/nototools/family_name_info_p2.xml
+++ b/nototools/family_name_info_p2.xml
@@ -120,6 +120,7 @@
   <info family="sans-zsym" omit_regular="t" />
   <info family="serif-armn" omit_regular="t" />
   <info family="serif-beng" omit_regular="t" />
+  <info family="serif-deva" omit_regular="t" />
   <info family="serif-geor" omit_regular="t" />
   <info family="serif-gujr" omit_regular="t" />
   <info family="serif-khmr" omit_regular="t" />

--- a/nototools/family_name_info_p3.xml
+++ b/nototools/family_name_info_p3.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf8'?>
-<family_name_data date="2016-04-29">
+<family_name_data date="2016-05-19">
   <info family="arimo-lgc" />
   <info family="cousine-lgc" />
   <info family="emoji-zsye" />
@@ -9,130 +9,195 @@
   <info family="naskh-arab" />
   <info family="naskh-arab-ui" />
   <info family="nastaliq-aran" />
-  <info family="sans-arab" family_name_style="short" use_preferred="t" />
+  <info family="sans-adlm" />
+  <info family="sans-aghb" />
+  <info family="sans-ahom" />
+  <info family="sans-arab-new" family_name_style="very short" use_preferred="t" />
+  <info family="sans-arab-new-ui" family_name_style="extra short" use_preferred="t" />
   <info family="sans-armi" />
   <info family="sans-armn" family_name_style="very short" use_preferred="t" />
   <info family="sans-avst" />
   <info family="sans-bali" />
   <info family="sans-bamu" />
+  <info family="sans-bass" />
   <info family="sans-batk" />
-  <info family="sans-beng" />
-  <info family="sans-beng-ui" />
+  <info family="sans-beng" family_name_style="short" use_preferred="t" />
+  <info family="sans-beng-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-bhks" />
   <info family="sans-brah" />
   <info family="sans-bugi" />
   <info family="sans-buhd" />
-  <info family="sans-cans" />
+  <info family="sans-cakm" />
+  <info family="sans-cans" family_name_style="extra short" use_preferred="t" />
   <info family="sans-cari" />
   <info family="sans-cham" />
-  <info family="sans-cher" />
+  <info family="sans-cham-new" use_preferred="t" />
+  <info family="sans-cher" use_preferred="t" />
   <info family="sans-cjk-jp" use_preferred="t" />
   <info family="sans-cjk-kr" use_preferred="t" />
   <info family="sans-cjk-sc" use_preferred="t" />
   <info family="sans-cjk-tc" use_preferred="t" />
   <info family="sans-copt" />
   <info family="sans-cprt" />
-  <info family="sans-deva" family_name_style="short" use_preferred="t" />
-  <info family="sans-deva-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-deva" family_name_style="very short" use_preferred="t" />
+  <info family="sans-deva-ui" family_name_style="extra short" use_preferred="t" />
   <info family="sans-dsrt" />
+  <info family="sans-dupl" />
   <info family="sans-egyp" />
-  <info family="sans-ethi" />
+  <info family="sans-elba" />
+  <info family="sans-ethi" family_name_style="very short" use_preferred="t" />
   <info family="sans-geor" family_name_style="very short" use_preferred="t" />
   <info family="sans-glag" />
   <info family="sans-goth" />
-  <info family="sans-gujr" />
-  <info family="sans-gujr-ui" />
-  <info family="sans-guru" />
-  <info family="sans-guru-ui" />
+  <info family="sans-gran" />
+  <info family="sans-gujr" family_name_style="very short" use_preferred="t" />
+  <info family="sans-gujr-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-guru" family_name_style="very short" use_preferred="t" />
+  <info family="sans-guru-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-hano" />
   <info family="sans-hans" use_preferred="t" />
   <info family="sans-hant" use_preferred="t" />
-  <info family="sans-hebr" family_name_style="short" use_preferred="t" />
+  <info family="sans-hatr" />
+  <info family="sans-hebr" />
+  <info family="sans-hebr-new" family_name_style="very short" use_preferred="t" />
+  <info family="sans-hluw" />
+  <info family="sans-hmng" />
+  <info family="sans-hung" />
   <info family="sans-ital" />
   <info family="sans-java" />
   <info family="sans-jpan" use_preferred="t" />
   <info family="sans-kali" />
   <info family="sans-khar" />
   <info family="sans-khmr" />
+  <info family="sans-khmr-new" family_name_style="very short" use_preferred="t" />
+  <info family="sans-khmr-new-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-khmr-ui" />
-  <info family="sans-knda" />
-  <info family="sans-knda-ui" />
+  <info family="sans-khoj" />
+  <info family="sans-knda" family_name_style="short" use_preferred="t" />
+  <info family="sans-knda-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-kore" use_preferred="t" />
   <info family="sans-kthi" />
   <info family="sans-lana" />
   <info family="sans-laoo" />
+  <info family="sans-laoo-new" family_name_style="short" use_preferred="t" />
+  <info family="sans-laoo-new-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-laoo-ui" />
   <info family="sans-lepc" />
-  <info family="sans-lgc" />
+  <info family="sans-lgc" family_name_style="short" use_preferred="t" />
   <info family="sans-lgc-display" family_name_style="short" use_preferred="t" />
-  <info family="sans-lgc-ui" family_name_style="short" use_preferred="t" />
+  <info family="sans-lgc-ui" />
   <info family="sans-limb" />
+  <info family="sans-lina" />
   <info family="sans-linb" />
   <info family="sans-lisu" />
   <info family="sans-lyci" />
   <info family="sans-lydi" />
+  <info family="sans-mahj" />
   <info family="sans-mand" />
-  <info family="sans-mlym" />
-  <info family="sans-mlym-ui" />
+  <info family="sans-mani" />
+  <info family="sans-marc" />
+  <info family="sans-mend" />
+  <info family="sans-merc" />
+  <info family="sans-mero" />
+  <info family="sans-mlym" family_name_style="very short" use_preferred="t" />
+  <info family="sans-mlym-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-modi" />
   <info family="sans-mong" />
-  <info family="sans-mono-mono" family_name_style="short" use_preferred="t" />
+  <info family="sans-mroo" />
   <info family="sans-mtei" />
-  <info family="sans-mymr" />
-  <info family="sans-mymr-ui" />
+  <info family="sans-mult" />
+  <info family="sans-mymr" family_name_style="short" use_preferred="t" />
+  <info family="sans-mymr-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-narb" />
+  <info family="sans-nbat" />
+  <info family="sans-newa" />
   <info family="sans-nkoo" />
   <info family="sans-ogam" />
   <info family="sans-olck" />
   <info family="sans-orkh" />
-  <info family="sans-orya" />
-  <info family="sans-orya-ui" />
+  <info family="sans-orya" use_preferred="t" />
+  <info family="sans-orya-ui" use_preferred="t" />
+  <info family="sans-osge" />
   <info family="sans-osma" />
+  <info family="sans-palm" />
+  <info family="sans-pauc" />
+  <info family="sans-perm" />
   <info family="sans-phag" />
   <info family="sans-phli" />
+  <info family="sans-phlp" />
   <info family="sans-phnx" />
+  <info family="sans-plrd" />
   <info family="sans-prti" family_name_style="extra short" />
   <info family="sans-rjng" />
   <info family="sans-runr" />
   <info family="sans-samr" />
   <info family="sans-sarb" />
   <info family="sans-saur" />
+  <info family="sans-sgnw" />
   <info family="sans-shaw" />
-  <info family="sans-sinh" />
+  <info family="sans-shrd" />
+  <info family="sans-sidd" />
+  <info family="sans-sind" />
+  <info family="sans-sinh" family_name_style="short" use_preferred="t" />
+  <info family="sans-sora" />
   <info family="sans-sund" />
   <info family="sans-sylo" />
-  <info family="sans-syrc-eastern" />
-  <info family="sans-syrc-estrangela" />
-  <info family="sans-syrc-western" />
+  <info family="sans-sym2" />
+  <info family="sans-syrc-eastern" family_name_style="short" use_preferred="t" />
+  <info family="sans-syrc-estrangela" family_name_style="very short" use_preferred="t" />
+  <info family="sans-syrc-western" family_name_style="short" use_preferred="t" />
   <info family="sans-tagb" />
+  <info family="sans-takr" />
   <info family="sans-tale" />
   <info family="sans-talu" />
-  <info family="sans-taml" />
-  <info family="sans-taml-ui" />
+  <info family="sans-taml" family_name_style="short" use_preferred="t" />
+  <info family="sans-taml-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-tang" />
   <info family="sans-tavt" />
-  <info family="sans-telu" />
-  <info family="sans-telu-ui" />
+  <info family="sans-telu" family_name_style="short" use_preferred="t" />
+  <info family="sans-telu-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-tfng" />
   <info family="sans-tglg" />
-  <info family="sans-thaa" />
-  <info family="sans-thai" use_preferred="t" />
+  <info family="sans-thaa" use_preferred="t" />
+  <info family="sans-thai" />
+  <info family="sans-thai-new" family_name_style="very short" use_preferred="t" />
+  <info family="sans-thai-new-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-thai-ui" />
-  <info family="sans-tibt" />
+  <info family="sans-tibt" use_preferred="t" />
+  <info family="sans-tirh" />
   <info family="sans-ugar" />
   <info family="sans-vaii" />
+  <info family="sans-wara" />
   <info family="sans-xpeo" />
   <info family="sans-xsux" />
   <info family="sans-yiii" />
-  <info family="sans-zsym" />
-  <info family="serif-armn" />
-  <info family="serif-beng" />
+  <info family="sans-zsym" use_preferred="t" />
+  <info family="serif-arab" family_name_style="short" use_preferred="t" />
+  <info family="serif-armn" family_name_style="very short" use_preferred="t" />
+  <info family="serif-beng" family_name_style="very short" use_preferred="t" />
+  <info family="serif-deva" family_name_style="very short" use_preferred="t" />
+  <info family="serif-ethi" use_preferred="t" />
   <info family="serif-geor" family_name_style="very short" use_preferred="t" />
-  <info family="serif-gujr" />
+  <info family="serif-gujr" use_preferred="t" />
+  <info family="serif-guru" use_preferred="t" />
+  <info family="serif-hebr" family_name_style="short" use_preferred="t" />
   <info family="serif-khmr" />
-  <info family="serif-knda" />
+  <info family="serif-khmr-new" family_name_style="very short" use_preferred="t" />
+  <info family="serif-knda" use_preferred="t" />
   <info family="serif-laoo" />
+  <info family="serif-laoo-new" family_name_style="very short" use_preferred="t" />
   <info family="serif-lgc" family_name_style="short" use_preferred="t" />
   <info family="serif-lgc-display" family_name_style="short" use_preferred="t" />
-  <info family="serif-mlym" />
-  <info family="serif-taml" />
-  <info family="serif-telu" />
-  <info family="serif-thai" use_preferred="t" />
+  <info family="serif-mlym" use_preferred="t" />
+  <info family="serif-mymr" family_name_style="very short" use_preferred="t" />
+  <info family="serif-orya" use_preferred="t" />
+  <info family="serif-sinh" family_name_style="very short" use_preferred="t" />
+  <info family="serif-taml" family_name_style="short" use_preferred="t" />
+  <info family="serif-taml-slanted" family_name_style="extra short" use_preferred="t" />
+  <info family="serif-telu" family_name_style="short" use_preferred="t" />
+  <info family="serif-thaa" use_preferred="t" />
+  <info family="serif-thai" family_name_style="short" use_preferred="t" />
+  <info family="serif-tibt" use_preferred="t" />
   <info family="tinos-lgc" />
+  <info family="zmth" />
 </family_name_data>

--- a/nototools/familyname_and_styles.txt
+++ b/nototools/familyname_and_styles.txt
@@ -1,0 +1,206 @@
+# See planning spreadsheet for more info.
+# This includes some 'grandfathered' fonts from phase 2,
+# might not want to include them.
+
+-- TRBH/CR/RI --
+NotoSans
+NotoSansDisplay
+-- TRBH/CR --
+NotoSansMonospace
+-- TRBH/CR/RI --
+NotoSerif
+NotoSerifDisplay
+-- TRH --
+NotoSansSymbols
+-- R --
+NotoSansSymbols2
+NotoMath
+-- RB --
+NotoSansThai
+NotoSansThaiUI
+-- TRBH/CR --
+NotoSansThaiNew
+NotoSansThaiNewUI
+NotoSerifThai
+-- R --
+NotoSansHebrew
+-- TRBH/CR --
+NotoSansHebrewNew
+NotoSerifHebrew  # no New
+NotoSansDevanagari
+NotoSansDevanagariUI
+NotoSerifDevanagari
+NotoSansArabicNew
+NotoSansArabicNewUI
+NotoSerifArabic  # was Naskh
+NotoSansGeorgian
+NotoSerifGeorgian
+NotoSansTamil
+NotoSansTamilUI
+NotoSerifTamil
+NotoSerifTamilSlanted
+NotoSansBengali
+NotoSansBengaliUI
+NotoSerifBengali
+NotoSansArmenian
+NotoSerifArmenian
+NotoSansMyanmar
+NotoSansMyanmarUI
+NotoSerifMyanmar
+NotoSansKhmerNew  # mignt not use New
+NotoSansKhmerNewUI  # might not use New
+NotoSerifKhmerNew  # might not use New
+NotoSansSinhala
+NotoSerifSinhala
+NotoSansLaoNew  # might not use New
+NotoSansLaoNewUI # might not use New
+NotoSerifLaoNew  # might not use New
+NotoSansTelugu
+NotoSansTeluguUI
+NotoSerifTelugu
+NotoSansKannada
+NotoSansKannadaUI
+-- TRBH --
+NotoSerifKannada
+-- TRBH/CR --
+NotoSansGujarati
+NotoSansGujaratiUI
+-- TRBH --
+NotoSerifGujarati
+-- TRBH/CR --
+NotoSansGurmukhi
+NotoSansGurmukhiUI
+-- TRBH --
+NotoSerifGurmukhi
+-- TRBH/CR --
+NotoSansMalayalam
+NotoSansMalayalamUI
+-- TRBH --
+NotoSerifMalayalam
+-- TRBH/CR --
+NotoSansEthiopic
+-- TRBH --
+NotoSerifEthiopic
+-- RB --
+NotoNastaliqUrdu
+-- TRH --
+NotoSansOriya
+NotoSansOriyaUI
+NotoSerifOriya
+NotoSansThaana
+NotoSerifThaana
+NotoSansTibetan
+NotoSerifTibetan
+NotoSansChamNew  # might not use New
+NotoSansSyriacEastern
+NotoSansSyriacWestern
+NotoSansSyriacEstrangela  # Estrangelo on spreadsheet?
+NotoSansCanadianAboriginal  # CanadianSyllabics on spreadsheet?
+NotoSansCherokee
+-- R --
+NotoSansAdlam
+NotoSansChakma
+NotoSansMarchen
+NotoSansMendeKikakui
+NotoSansMiao
+NotoSansMro
+NotoSansNewa
+NotoSansOsage
+NotoSansPahawhHmong
+NotoSansSharada
+NotoSansSiddham
+NotoSansSignwriting
+NotoSansTakri
+NotoSansTirhuta
+NotoSansWarangCiti
+NotoSansAhom
+NotoSansAnatolianHieroglyphs
+NotoSansAvestan
+NotoSansBalinese
+NotoSansBamum
+NotoSansBassaVah
+NotoSansBatak
+NotoSansBhaiksuki
+NotoSansBrahmi
+NotoSansBuginese
+NotoSansBuhid
+NotoSansCarian
+NotoSansCaucasianAlbanian
+NotoSansCoptic
+NotoSansCypriot
+NotoSansDeseret
+NotoSansDuployan
+NotoSansElbasan
+NotoSansEgyptianHieroglyphs
+NotoSansGlagolitic
+NotoSansGothic
+NotoSansGrantha
+NotoSansHanunoo
+NotoSansHatran
+NotoSansImperialAramaic
+NotoSansInscriptionalPahlavi
+NotoSansInscriptionalParthian
+NotoSansJavanese
+NotoSansKaithi
+NotoSansKayahLi
+NotoSansKharoshthi
+NotoSansKhojki
+NotoSansKhudawadi
+NotoSansLepcha
+NotoSansLimbu
+NotoSansLinearA
+NotoSansLinearB
+NotoSansLisu
+NotoSansLycian
+NotoSansLydian
+NotoSansMahajani
+NotoSansMandaic
+NotoSansManichaean
+NotoSansMeeteiMayek
+NotoSansMeroiticCursive
+NotoSansMeroiticHieroglyphs
+NotoSansModi
+NotoSansMongolian
+NotoSansMultani
+NotoSansNKo
+NotoSansNabataean
+NotoSansNewTaiLue
+NotoSansOgham
+NotoSansOlChiki
+NotoSansOldHungarian
+NotoSansOldItalic
+NotoSansOldNorthArabian
+NotoSansOldPermic
+NotoSansOldPersian
+NotoSansOldSouthArabian
+NotoSansOldTurkic
+NotoSansOsmanya
+NotoSansPalmyrene
+NotoSansPauCinHau
+NotoSansPhagsPa
+NotoSansPhoenician
+NotoSansPsalterPahlavi
+NotoSansRejang
+NotoSansRunic
+NotoSansSamaritan
+NotoSansSaurashtra
+NotoSansShavian
+# NotoSansShorthandFormatControls (spreadsheet had this, it's Duployan)
+NotoSansSoraSompeng
+NotoSansSundanese
+NotoSansSumeroAkkadianCuneiform
+NotoSansSylotiNagri
+NotoSansTagbanwa
+NotoSansTagalog
+NotoSansTaiLe
+NotoSansTaiTham
+NotoSansTaiViet
+NotoSansTangut
+NotoSansTifinagh
+NotoSansUgaritic
+NotoSansVai
+NotoSansYi
+# NotoSansZanabazarSquare (not in Unicode 9)
+-- RB/R/RI --
+Arimo
+Tinos

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -134,9 +134,9 @@ _FONT_NAME_REGEX = (
     # family should be prepended - this is so Roboto can be used with unittests
     # that use this regex to parse.
     '(Sans|Serif|Naskh|Kufi|Nastaliq|Emoji|ColorEmoji)?'
-    '(Mono)?'
+    '(Mono(?:space)?)?'
     '(.*?)'
-    '(Eastern|Estrangela|Western|New)?'
+    '(Eastern|Estrangela|Western|Slanted|New)?'
     '(UI)?'
     '(Display)?'
     '-?'
@@ -208,6 +208,8 @@ def get_noto_font(filepath, family_name='Arimo|Cousine|Tinos|Noto',
   elif script == 'CJK':
     # leave script as-is
     pass
+  elif script == 'Symbols2':
+    script = 'SYM2'
   else:
     try:
       script = convert_to_four_letter(script)

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -745,11 +745,12 @@ def _dump_family_names(notofonts, family_to_name_info, phase):
   err_names = []
   for font in sorted(notofonts, key=lambda f: f.filepath):
     name_data = name_table_data(font, family_to_name_info, phase)
+    print
     print font.filepath
     if _dump_name_data(name_data):
       err_names.append(font.filepath)
   if err_names:
-    print '%d names too long:\n  %s' % (
+    print '## %d names too long:\n  %s' % (
         len(err_names), '\n  '.join(err_names))
 
 
@@ -784,6 +785,11 @@ def _info(fonts):
         family, '\n  '.join(sorted(family_to_subfamilies[family])))
 
 
+def _read_filename_list(filenames):
+  with open(filenames, 'r') as f:
+    return [n.strip() for n in f if n]
+
+
 def _collect_paths(dirs, files):
   paths = []
   if dirs:
@@ -791,7 +797,11 @@ def _collect_paths(dirs, files):
       d = tool_utils.resolve_path(d)
       paths.extend(n for n in glob.glob(path.join(d, '*')))
   if files:
-    paths.extend(tool_utils.resolve_path(f) for f in files)
+    for fname in files:
+      if fname[0] == '@':
+        paths.extend(_read_filename_list(fname[1:]))
+      else:
+        paths.append(tool_utils.resolve_path(f))
   return paths
 
 
@@ -831,7 +841,8 @@ def main():
       '-d', '--dirs', metavar='dir', help='font directories to examine '
       '(use "[noto]" for noto fonts/cjk/emoji font dirs)', nargs='+')
   parser.add_argument(
-      '-f', '--files', metavar='fname', help='fonts to examine', nargs='+')
+      '-f', '--files', metavar='fname', help='fonts to examine, prefix with'
+      '\'@\' to read list from file', nargs='+')
   parser.add_argument(
       'cmd', metavar='cmd', help='operation to perform (%s)' % ', '.join(CMDS),
       choices=CMDS)


### PR DESCRIPTION
Updates the name data xml files for phase 2 and 3.  Phase 2 had omitted serif Devanagari, this fixes a bug reported by MTI via email.  To prevent further hiccups like this in phase 3, I decided to add all the planned phase 3 fonts to the data.

To do this I created a data file based on the planning spreadsheet page that lists the planned masters, wrote a tool that processes this and generates a list of filenames, and updated the name generation tool to take a list of names as input in addition to individual names and dirs on the command line, and ran the tool to generate the new phase 3 name data file.  I also updated noto_fonts to allow it to parse two new font file names it wasn't prepared for.