### PR TITLE
Fix use of fonts.conf

### DIFF
--- a/nototools/create_image.py
+++ b/nototools/create_image.py
@@ -23,8 +23,21 @@ import argparse
 import codecs
 import os
 from os import path
-fonts_conf = path.abspath(path.join (path.dirname(__file__), "fonts.conf"))
+
+# Workaround fontconfig resolving relative paths w.r.t. current directory,
+# when we want it relative to this directory.
+curdir = path.abspath(path.dirname(__file__))
+os.putenv("XDG_CONFIG_HOME", curdir)
+os.putenv("XDG_DATA_HOME", curdir)
+os.putenv("XDG_CACHE_HOME", curdir)
+
+# This is all we'd need if fontconfig resolved paths differently.
+#
+# NOTE: if the noto fonts are not in the directories listed by fonts.conf,
+# you will have to edit fonts.conf for your environment.
+fonts_conf = path.join(curdir, "fonts.conf")
 os.putenv("FONTCONFIG_FILE", fonts_conf)
+
 
 import cairo
 import pango

--- a/nototools/fonts.conf
+++ b/nototools/fonts.conf
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-  <dir>../../noto-fonts</dir>
-  <dir>../../noto-cjk</dir>
-  <dir>../../noto-emoji/fonts</dir>
+  <dir prefix="xdg">../../noto-fonts/hinted</dir>
+  <dir prefix="xdg">../../noto-fonts/unhinted</dir>
+  <dir prefix="xdg">../../noto-cjk</dir>
+  <dir prefix="xdg">../../noto-emoji/fonts</dir>
 
   <include>/etc/fonts/conf.d</include>
 


### PR DESCRIPTION
fonts.conf uses relative paths to access the noto-fonts, noto-cjk, and
noto-emoji repos (this is a bit broken, as there's nothing to enforce
their relative locations w.r.t. the nototools repo).  Unfortunately,
fontconfig resolves relative paths w.r.t the current directory, not the
directory containing fonts.conf.  This means callers of create_image.py
see different font directories based on what the current directory is,
which is bad, especially since these failures are silent by default.

This particular problem is worked around by setting xdg as the prefix
in the fonts.conf directories, and by setting the XDG_XXX_HOME environment
variables in create_image.

In addition to this change, fonts.conf was modified to specify only the
hinted and unhinted subdirectories of noto-fonts, in order to avoid
picking up multiple phase 3 fonts that are still under development.