### PR TITLE
Replace caret with tilde in Guarani sample text.

### DIFF
--- a/sample_texts/gn-Latn_udhr.txt
+++ b/sample_texts/gn-Latn_udhr.txt
@@ -1,1 +1,1 @@
-Mayma yvypóra ou ko yvy ári iñapytl'yre ha eteîcha dignidad ha derecho jeguerekópe; ha ikatu rupi oikuaa añetéva ha añete'yva, iporâva ha ivaíva, tekotevê pehenguéicha oiko oñondivekuéra.
+Mayma yvypóra ou ko yvy ári iñapytl'yre ha eteĩcha dignidad ha derecho jeguerekópe; ha ikatu rupi oikuaa añetéva ha añete'yva, iporãva ha ivaíva, tekotevê pehenguéicha oiko oñondivekuéra.


### PR DESCRIPTION
Wikipedia shows tilde is the preferred usage though other diacritics have
been used in the past, which is probably why this sample had caret.

Fixes #228.