### PR TITLE
dump_otl: fix GSUB lookup_type=2, use subtable.mapping

### DIFF
--- a/nototools/dump_otl.py
+++ b/nototools/dump_otl.py
@@ -133,12 +133,8 @@ def dump_gsub_subtable(lookup_type, subtable):
             print_indented('sub %s by %s;' % (key, subtable.mapping[key]))
 
     elif lookup_type == 2:
-        count = subtable.SequenceCount
-        assert len(subtable.Coverage.glyphs) == len(subtable.Sequence) == count
-        for index in range(count):
-            print_indented('sub %s by %s;' % (
-                subtable.Coverage.glyphs[index],
-                ' '.join(subtable.Sequence[index].Substitute)))
+        for key, value in sorted(subtable.mapping.items()):
+            print_indented('sub %s by %s;' % (key, ' '.join(value)))
 
     elif lookup_type == 3:
         for key in sorted(subtable.alternates.keys()):


### PR DESCRIPTION
Use subtable.mapping instead of subtable.SequenceCount, subtable.Coverage and subtable.Sequence to avoid the following:

```
Traceback (most recent call last):
  File "/usr/local/bin/dump_otl.py", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/moyogo/nototools/nototools/dump_otl.py", line 493, in <module>
    main()
  File "/Users/moyogo/nototools/nototools/dump_otl.py", line 489, in main
    dump_otl_table(font, 'GSUB')
  File "/Users/moyogo/nototools/nototools/dump_otl.py", line 478, in dump_otl_table
    dump_lookup_list(table.LookupList.Lookup, table_name)
  File "/Users/moyogo/nototools/nototools/dump_otl.py", line 456, in dump_lookup_list
    dump_gsub_subtable(lookup.LookupType, subtable)
  File "/Users/moyogo/nototools/nototools/dump_otl.py", line 136, in dump_gsub_subtable
    count = subtable.SequenceCount
  File "/Users/moyogo/fonttools/Lib/fontTools/ttLib/tables/otBase.py", line 543, in __getattr__
    raise AttributeError(attr)
AttributeError: SequenceCount
```