### PR TITLE
Updates for font name parsing and name generation.

### DIFF
--- a/nototools/family_name_info_p3.xml
+++ b/nototools/family_name_info_p3.xml
@@ -171,6 +171,7 @@
   <info family="sans-xpeo" />
   <info family="sans-xsux" />
   <info family="sans-yiii" />
+  <info family="sans-zmth" />
   <info family="sans-zsym" use_preferred="t" />
   <info family="serif-arab" family_name_style="short" use_preferred="t" />
   <info family="serif-armn" family_name_style="very short" use_preferred="t" />

--- a/nototools/mti_cmap_data.py
+++ b/nototools/mti_cmap_data.py
@@ -24,6 +24,12 @@ from nototools import cmap_data
 from nototools import tool_utils
 from nototools import unicode_data
 
+# exceptions for script codes that are not actual script codes, but
+# our own custom keys.
+_SCRIPT_KEY_NAMES = [
+    ('SYM2', 'Symbols2')
+]
+
 def get_script_for_name(script_name):
   starred = False
   if script_name[-1] == '*':
@@ -31,6 +37,10 @@ def get_script_for_name(script_name):
     script_name = script_name[:-1]
   if script_name in ['LGC', 'MONO', 'MUSIC', 'SYM2']:
     return script_name, starred
+
+  for k, name in _SCRIPT_KEY_NAMES:
+    if script_name == name:
+      return k, starred
 
   code = unicode_data.script_code(script_name)
   if code == 'Zzzz':
@@ -118,6 +128,10 @@ def csv_to_xml(csv_file, xml_file, scripts, exclude_scripts):
 
 
 def _script_to_name(script):
+  for k, name in _SCRIPT_KEY_NAMES:
+    if script == k:
+      return name
+
   try:
     return unicode_data.human_readable_script_name(script)
   except KeyError:

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -77,9 +77,10 @@ def preferred_script_name(script_key):
 
 
 _script_key_to_report_name = {
-    'Aran': '(Urdu)',
+    'Aran': '(Urdu)',  # phase 2 usage
     'HST': '(Historic)',
-    'LGC': '(LGC)'
+    'LGC': '(LGC)',
+    'SYM2': 'Symbols2'
 }
 def script_name_for_report(script_key):
     return (_script_key_to_report_name.get(script_key, None) or
@@ -140,7 +141,7 @@ _FONT_NAME_REGEX = (
     '(UI)?'
     '(Display)?'
     '-?'
-    '((?:Semi)?Condensed)?'
+    '((?:Semi|Extra)?Condensed)?'
     '(|%s)?' % '|'.join(WEIGHTS.keys()) +
     '(Italic)?'
     '\.(ttf|ttc|otf)')
@@ -184,7 +185,7 @@ def get_noto_font(filepath, family_name='Arimo|Cousine|Tinos|Noto',
 
   is_mono = mono == 'Mono'
 
-  if width not in [None, '', 'Condensed', 'SemiCondensed']:
+  if width not in [None, '', 'Condensed', 'SemiCondensed', 'ExtraCondensed']:
     print >> sys.stderr, 'noto_fonts: Unexpected width "%s"' % width
     if width in ['SemiCond', 'Narrow']:
       width = 'SemiCondensed'

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -121,6 +121,7 @@ _SCRIPT_KEY_TO_FONT_NAME = {
     'LGC': None,
     'Zsye': None,
     'MONO': None,
+    'SYM2': 'Symbols2',
 }
 
 
@@ -240,7 +241,7 @@ def _shift_parts(family_parts, subfamily_parts, stop_fn):
 
 
 _WWS_RE = re.compile(
-    '(?:(?:Semi)?Condensed|%s|Italic)$' % '|'.join(noto_fonts.WEIGHTS))
+    '(?:(?:Semi|Extra)?Condensed|%s|Italic)$' % '|'.join(noto_fonts.WEIGHTS))
 def _is_wws_part(part):
   return _WWS_RE.match(part)
 
@@ -269,7 +270,9 @@ def _original_parts(family_parts, subfamily_parts, no_style_linking=False):
 _SHORT_NAMES = {
     'Condensed': 'Cond',
     'SemiCondensed': 'SemCond',
+    'ExtraCondensed': 'ExtCond',
     'SemiLight': 'SemLt',
+    'ExtraLight': 'ExtLt',
     'Medium': 'Med',
     'SemiBold': 'SemBd',
     'ExtraBold': 'ExtBd',
@@ -280,9 +283,11 @@ _SHORT_NAMES = {
 _VERY_SHORT_NAMES = {
     'Condensed': 'Cn',
     'SemiCondensed': 'SmCn',
+    'ExtraCondensed': 'XCn',
     'Thin': 'Th',
     'Light': 'Lt',
     'SemiLight': 'SmLt',
+    'ExtraLight': 'XLt',
     'Medium': 'Md',
     'Bold': 'Bd',
     'SemiBold': 'SmBd',
@@ -571,7 +576,7 @@ _NON_ORIGINAL_WEIGHT_PARTS = frozenset(
     if w not in ['Bold', 'Regular'])
 _ORIGINAL_PARTS = frozenset(['Bold', 'Regular', 'Italic'])
 _WWS_PARTS = frozenset(
-    ['SemiCondensed', 'Condensed', 'Italic'] +
+    ['SemiCondensed', 'ExtraCondensed', 'Condensed', 'Italic'] +
     list(noto_fonts.WEIGHTS))
 
 
@@ -801,7 +806,7 @@ def _collect_paths(dirs, files):
       if fname[0] == '@':
         paths.extend(_read_filename_list(fname[1:]))
       else:
-        paths.append(tool_utils.resolve_path(f))
+        paths.append(tool_utils.resolve_path(fname))
   return paths
 
 
@@ -874,7 +879,7 @@ def main():
     if not path.exists(args.info_file):
       print '"%s" does not exist.' % args.info_file
       return
-    _dump(fonts, args.info_file)
+    _dump(fonts, args.info_file, args.phase)
   elif args.cmd == 'write':
     if not args.phase:
       print 'Must specify phase when generating info.'


### PR DESCRIPTION
- Defines 'Symbols2' as the name for script key 'SYM2'
- Supports 'ExtraCondensed' as a style name (for testing use)
- Partial support for 'ExtraLight' as a weight name (for testing use)
- Adds name entry for sans-zmth (no font yet)
- Fixes two bugs in handling noto_names arguments
