### PR TITLE
[requirements] Added missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-FontTools==3.0
+booleanOperations==0.6.2
+defcon==0.2.0
+fonttools==3.2.1
+pyclipper==1.0.5
+ufoLib==2.0.0


### PR DESCRIPTION
Hey,

I found a few dependencies were missing.

```
(env)Marcs-Air:nototools marc$ python notodiff.py
Traceback (most recent call last):
  File "notodiff.py", line 30, in <module>
    from nototools import gpos_diff, gsub_diff, shape_diff
  File "/Users/marc/Documents/googlefonts/nototools/env/lib/python2.7/site-packages/nototools-0.0.1-py2.7.egg/nototools/shape_diff.py", line 37, in <module>
    import booleanOperations
ImportError: No module named booleanOperations
```

```
(env)Marcs-Air:nototools marc$ python notodiff.py
Traceback (most recent call last):
  File "notodiff.py", line 30, in <module>
    from nototools import gpos_diff, gsub_diff, shape_diff
  File "/Users/marc/Documents/googlefonts/nototools/env/lib/python2.7/site-packages/nototools-0.0.1-py2.7.egg/nototools/shape_diff.py", line 38, in <module>
    from defcon import Glyph
ImportError: No module named defcon
```