### PR TITLE
notodiff optimizations

### DIFF
--- a/nototools/hb_input_test.py
+++ b/nototools/hb_input_test.py
@@ -257,16 +257,20 @@ class HbInputGeneratorTest(unittest.TestCase):
     def test_is_sublist(self):
         g = self._make_generator('')
         self.assertTrue(g._is_sublist([], []))
+        self.assertFalse(g._is_sublist([], [1]))
         self.assertTrue(g._is_sublist([1, 2, 3], [2, 3]))
         self.assertFalse(g._is_sublist([1, 2, 3], [1, 3]))
 
-    def test_permutations(self):
+    def test_min_permutation(self):
         g = self._make_generator('')
-        self.assertEqual(g._permutations([[1], [2]]), [[1, 2]])
-        self.assertEqual(g._permutations([[1], [], [2]]), [])
-        self.assertEqual(
-            g._permutations([[1, 2], [3, 4]]),
-            [[1, 3], [1, 4], [2, 3], [2, 4]])
+        self.assertEqual(g._min_permutation(
+            [[1, 2], [3, 4], [5, 6]], [2, 3]), [2, 3, 5])
+        self.assertEqual(g._min_permutation(
+            [[1, 2], [3, 4], [5, 6]], [3, 6]), [1, 3, 6])
+        self.assertEqual(g._min_permutation(
+            [[1, 2], [3, 4], [5, 6]], [1, 4, 5]), [1, 4, 5])
+        self.assertEqual(g._min_permutation(
+            [[1], [], [2]], [1]), [])
 
 if __name__ == '__main__':
     unittest.main()

--- a/nototools/notodiff.py
+++ b/nototools/notodiff.py
@@ -33,7 +33,9 @@ from nototools import gpos_diff, gsub_diff, shape_diff
 logger = logging.getLogger('notodiff')
 
 
-def _shape(path_a, path_b, stats, diff_type, render_path, diff_threshold=0):
+def _shape(
+        path_a, path_b, stats, diff_type, font_size, render_path,
+        diff_threshold=0):
     """Do a shape comparison (glyph area or rendered) and add results to stats.
 
     path_a and b refer to binary font files (OTF or TTF). stats should be a
@@ -52,7 +54,7 @@ def _shape(path_a, path_b, stats, diff_type, render_path, diff_threshold=0):
     elif diff_type == 'area-shape-product':
         diff_finder.find_area_shape_diff_products()
     else:
-        diff_finder.find_rendered_diffs(render_path=render_path)
+        diff_finder.find_rendered_diffs(font_size, render_path)
 
 
 def _gpos(path_a, path_b, error_bound, out_lines, print_font=False):
@@ -125,6 +127,9 @@ def main():
     parser.add_argument('-w', '--whitelist', nargs='+', default=(),
                         help='list of one or more glyph names to ignore for '
                         'area or rendered differences')
+    parser.add_argument('--font-size', type=int, default=128,
+                        help='if DIFF_TYPE is "rendered", size to render '
+                        'samples at (default 128)')
     parser.add_argument('--render-path', help='if provided and DIFF_TYPE is '
                         '"rendered", saves comparison renderings here')
     parser.add_argument('--diff-threshold', type=float, default=0,
@@ -138,10 +143,11 @@ def main():
         stats = {}
         if args.match:
             _run_multiple(_shape, args.match, args.before, args.after, stats,
-                          args.diff_type, args.render_path, args.diff_threshold)
+                          args.diff_type, args.font_size, args.render_path,
+                          args.diff_threshold)
         else:
             _shape(args.before, args.after, stats, args.diff_type,
-                   args.render_path, args.diff_threshold)
+                   args.font_size, args.render_path, args.diff_threshold)
         print(shape_diff.ShapeDiffFinder.dump(
             stats, args.whitelist, args.out_lines,
             include_vals=(args.diff_type in ('area', 'area-shape-product')),

--- a/nototools/notodiff.py
+++ b/nototools/notodiff.py
@@ -22,6 +22,7 @@ differences from all pairs are shown first. For GPOS the pairs are still
 compared separately.
 """
 
+from __future__ import print_function
 
 import argparse
 import glob
@@ -66,15 +67,15 @@ def _gpos(path_a, path_b, error_bound, out_lines, print_font=False):
     """
 
     if print_font:
-        print '-- %s --' % os.path.basename(path_a)
-        print
+        print('-- %s --' % os.path.basename(path_a))
+        print()
     diff_finder = gpos_diff.GposDiffFinder(path_a, path_b, error_bound,
                                            out_lines)
-    print diff_finder.find_kerning_diffs()
-    print diff_finder.find_mark_class_diffs()
-    print diff_finder.find_positioning_diffs()
-    print diff_finder.find_positioning_diffs(mark_type='mark')
-    print
+    print(diff_finder.find_kerning_diffs())
+    print(diff_finder.find_mark_class_diffs())
+    print(diff_finder.find_positioning_diffs())
+    print(diff_finder.find_positioning_diffs(mark_type='mark'))
+    print()
 
 
 def _gsub(path_a, path_b, out_lines, print_font=False):
@@ -86,9 +87,9 @@ def _gsub(path_a, path_b, out_lines, print_font=False):
     """
 
     if print_font:
-        print '-- %s --' % os.path.basename(path_a)
+        print('-- %s --' % os.path.basename(path_a))
     diff_finder = gsub_diff.GsubDiffFinder(path_a, path_b, out_lines)
-    print diff_finder.find_gsub_diffs()
+    print(diff_finder.find_gsub_diffs())
     print
 
 

--- a/nototools/shape_diff.py
+++ b/nototools/shape_diff.py
@@ -18,8 +18,8 @@
 ShapeDiffFinder takes in two paths, to font binaries. It then provides methods
 which compare these fonts, storing results in a report dictionary. These methods
 are `find_area_diffs`, which compares glyph areas, `find_rendered_diffs`, which
-compares harfbuzz output using image magick, and `find_shape_diffs`, which takes
-the difference of shapes and calculates the area.
+compares harfbuzz output using PIL, and `find_shape_diffs`, which takes the
+difference of shapes and calculates the area.
 
 Some caveats: glyph areas can be the same even if the shapes are wildly
 different (though they're useful for shapes which should be identical except
@@ -103,7 +103,7 @@ class ShapeDiffFinder:
             stats.append((calc(areas), name, self.basepath, areas[0], areas[1]))
 
     def find_rendered_diffs(self, font_size=128, render_path=None):
-        """Find diffs of glyphs as rendered by harfbuzz + image magick."""
+        """Find diffs of glyphs as rendered by harfbuzz."""
 
         hb_input_generator_a = hb_input.HbInputGenerator(self.font_a)
         hb_input_generator_b = hb_input.HbInputGenerator(self.font_b)

--- a/nototools/shape_diff.py
+++ b/nototools/shape_diff.py
@@ -102,7 +102,7 @@ class ShapeDiffFinder:
         for name, areas in mismatched.items():
             stats.append((calc(areas), name, self.basepath, areas[0], areas[1]))
 
-    def find_rendered_diffs(self, font_size=256, render_path=None):
+    def find_rendered_diffs(self, font_size=128, render_path=None):
         """Find diffs of glyphs as rendered by harfbuzz + image magick."""
 
         hb_input_generator_a = hb_input.HbInputGenerator(self.font_a)

--- a/nototools/shape_diff.py
+++ b/nototools/shape_diff.py
@@ -28,6 +28,7 @@ for some offset). Image comparison is usually either slow (hi-res) or inaccurate
 large errors.
 """
 
+from __future__ import division
 
 import Image
 import os
@@ -180,8 +181,8 @@ class ShapeDiffFinder:
             width, height = max(width_a, width_b), height_a
 
             diff = 0
-            offset_a = (width - width_a) / 2
-            offset_b = (width - width_b) / 2
+            offset_a = (width - width_a) // 2
+            offset_b = (width - width_b) // 2
             for y in range(height):
                 for x in range(width):
                     ax = x - offset_a
@@ -191,7 +192,7 @@ class ShapeDiffFinder:
                         diff += 1
 
             if self.ratio_diffs:
-                diff = float(diff) / (width * height)
+                diff /= (width * height)
 
             if render_path and diff > self.diff_threshold:
                 img_cmp = Image.new('RGB', (width, height))
@@ -222,7 +223,7 @@ class ShapeDiffFinder:
             self, src_data, src_width, dst_data, width, height, channel):
         """Project a single-channel image onto a channel of an RGB image."""
 
-        offset = (width - src_width) / 2
+        offset = (width - src_width) // 2
         for y in range(height):
             for x in range(src_width):
                 src_i = x + y * src_width


### PR DESCRIPTION
Now we don't use image magick to save and compare every rendering, and a possible inefficiency when searching for harfbuzz input is addressed. Also adds a parameter for font size when rendering, and changes the default font size from 256pt to 128pt.

Depending on how many renderings actually need to be saved, this should cut rendering diff runtime by upwards of 80%. cc @marekjez86