### PR TITLE
Tweak notoconfig.

### DIFF
--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -693,8 +693,6 @@ def family_to_name_info_for_phase(phase):
   result = _PHASE_TO_NAME_INFO_CACHE.get(phase, None)
   if not result and phase in _PHASE_TO_FILENAME:
     tooldir = tool_utils.resolve_path('[tools]/nototools')
-    if not tooldir:
-      tooldir = path.abspath(path.dirname(__file__))
     result = read_family_name_info_file(
         path.join(tooldir, _PHASE_TO_FILENAME[phase]))
     _PHASE_TO_NAME_INFO_CACHE[phase] = result

--- a/nototools/tool_utils.py
+++ b/nototools/tool_utils.py
@@ -60,10 +60,7 @@ def resolve_path(somepath):
       key = 'afdko'
     else:
       key = 'noto_' + base
-    if not key in notoconfig.values:
-      print 'notoconfig has no entry for %s' % key
-      return None
-    base = notoconfig.values.get(key)
+    base = notoconfig.get(key)
     while rest.startswith(path.sep):
       rest = rest[len(path.sep):]
     somepath = path.join(base, rest)


### PR DESCRIPTION
It's really obscure when notoconfig fails because people don't have a
file set up.  Add some documentation, print a warning if it is not set
up, default 'noto_tools' to the root of the nototools repo containing
the file, and provide a getter that fails if a key is not defined
(except for noto_tools).