### PR TITLE
Use boundsPen to determine vertical extents in render.py.

### DIFF
--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -1117,11 +1117,14 @@ def check_font(font_props, filename_error,
 
         font_ymin = None
         font_ymax = None
+        glyph_set = font.getGlyphSet()
         for glyph_index in range(len(glyf_table.glyphOrder)):
             glyph_name = glyf_table.glyphOrder[glyph_index]
             glyph = glyf_table[glyph_name]
             # Compute the ink's yMin and yMax
-            ymin, ymax = render.get_glyph_cleaned_extents(glyph, glyf_table)
+
+            ttglyph = glyph_set[glyph_name]
+            ymin, ymax = render.get_glyph_cleaned_extents(ttglyph, glyph_set)
             font_ymin = render.min_with_none(font_ymin, ymin)
             font_ymax = render.max_with_none(font_ymax, ymax)
 


### PR DESCRIPTION
This changes the types of arguments to get_glyph_cleaned_extents.

The previous code attempted to optimize computing the vertical extents
by making assumptions about what kinds of transforms would be applied
to components (translations and positive scales).  This didn't support
flips, and also didn't support rotations, which some phase3 fonts use.
BoundsPen supports the omission of single-point contours, like the old
code did, and it's more general, so rather than try to extend the old
optimizations to cover these new cases it seemed cleanest to just use
BoundsPen.

This however means the old argument types (the 'glyf' table and
_g_l_y_f.Glyph objects returned from it) needed to be converted to
_TTGlyph and TTGlyphSet, and it seems best to instead just pass them
in.

The two direct callers of this api (and the caller in render.py)
were changed to pass in the right types.

This of course breaks anyone outside of nototools who might be using
this API.