### PR TITLE
Lint regular fix

### DIFF
--- a/nototools/data/family_name_info_p3.xml
+++ b/nototools/data/family_name_info_p3.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf8'?>
-<family_name_data date="2016-12-12">
+<family_name_data date="2016-12-14">
   <info family="arimo-lgc" />
   <info family="cousine-lgc" />
   <info family="emoji-zsye" />
   <info family="emoji-zsye-color" />
   <info family="kufi-arab" />
-  <info family="mono-mono" />
+  <info family="mono-mono" use_preferred="t" />
   <info family="naskh-arab" />
   <info family="naskh-arab-ui" />
   <info family="nastaliq-aran" />
@@ -30,7 +30,7 @@
   <info family="sans-cakm" />
   <info family="sans-cans" family_name_style="extra short" use_preferred="t" />
   <info family="sans-cari" />
-  <info family="sans-cham" />
+  <info family="sans-cham" use_preferred="t" />
   <info family="sans-cham-new" use_preferred="t" />
   <info family="sans-cher" use_preferred="t" />
   <info family="sans-cjk-jp" include_regular="t" use_preferred="t" />
@@ -58,7 +58,7 @@
   <info family="sans-hans" include_regular="t" use_preferred="t" />
   <info family="sans-hant" include_regular="t" use_preferred="t" />
   <info family="sans-hatr" />
-  <info family="sans-hebr" />
+  <info family="sans-hebr" family_name_style="short" use_preferred="t" />
   <info family="sans-hebr-new" family_name_style="very short" use_preferred="t" />
   <info family="sans-hluw" />
   <info family="sans-hmng" />
@@ -68,20 +68,20 @@
   <info family="sans-jpan" include_regular="t" use_preferred="t" />
   <info family="sans-kali" />
   <info family="sans-khar" />
-  <info family="sans-khmr" />
+  <info family="sans-khmr" family_name_style="short" use_preferred="t" />
   <info family="sans-khmr-new" family_name_style="very short" use_preferred="t" />
-  <info family="sans-khmr-new-ui" family_name_style="very short" use_preferred="t" />
-  <info family="sans-khmr-ui" />
+  <info family="sans-khmr-new-ui" family_name_style="extra short" use_preferred="t" />
+  <info family="sans-khmr-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-khoj" />
   <info family="sans-knda" family_name_style="short" use_preferred="t" />
   <info family="sans-knda-ui" family_name_style="very short" use_preferred="t" />
   <info family="sans-kore" include_regular="t" use_preferred="t" />
   <info family="sans-kthi" />
   <info family="sans-lana" />
-  <info family="sans-laoo" />
+  <info family="sans-laoo" family_name_style="short" use_preferred="t" />
   <info family="sans-laoo-new" family_name_style="short" use_preferred="t" />
   <info family="sans-laoo-new-ui" family_name_style="very short" use_preferred="t" />
-  <info family="sans-laoo-ui" />
+  <info family="sans-laoo-ui" family_name_style="short" use_preferred="t" />
   <info family="sans-lepc" />
   <info family="sans-lgc" family_name_style="short" use_preferred="t" />
   <info family="sans-lgc-display" family_name_style="short" use_preferred="t" />
@@ -100,7 +100,7 @@
   <info family="sans-merc" />
   <info family="sans-mero" />
   <info family="sans-mlym" family_name_style="very short" use_preferred="t" />
-  <info family="sans-mlym-ui" family_name_style="very short" use_preferred="t" />
+  <info family="sans-mlym-ui" family_name_style="extra short" use_preferred="t" />
   <info family="sans-modi" />
   <info family="sans-mong" />
   <info family="sans-mroo" />
@@ -144,7 +144,7 @@
   <info family="sans-sylo" />
   <info family="sans-sym2" />
   <info family="sans-syrc-eastern" family_name_style="short" use_preferred="t" />
-  <info family="sans-syrc-estrangela" family_name_style="very short" use_preferred="t" />
+  <info family="sans-syrc-estrangela" family_name_style="extra short" use_preferred="t" />
   <info family="sans-syrc-western" family_name_style="short" use_preferred="t" />
   <info family="sans-tagb" />
   <info family="sans-takr" />
@@ -159,10 +159,10 @@
   <info family="sans-tfng" />
   <info family="sans-tglg" />
   <info family="sans-thaa" use_preferred="t" />
-  <info family="sans-thai" />
+  <info family="sans-thai" use_preferred="t" />
   <info family="sans-thai-new" family_name_style="very short" use_preferred="t" />
   <info family="sans-thai-new-ui" family_name_style="very short" use_preferred="t" />
-  <info family="sans-thai-ui" />
+  <info family="sans-thai-ui" use_preferred="t" />
   <info family="sans-tibt" use_preferred="t" />
   <info family="sans-tirh" />
   <info family="sans-ugar" />
@@ -181,10 +181,10 @@
   <info family="serif-gujr" use_preferred="t" />
   <info family="serif-guru" use_preferred="t" />
   <info family="serif-hebr" family_name_style="short" use_preferred="t" />
-  <info family="serif-khmr" />
+  <info family="serif-khmr" family_name_style="short" use_preferred="t" />
   <info family="serif-khmr-new" family_name_style="very short" use_preferred="t" />
   <info family="serif-knda" use_preferred="t" />
-  <info family="serif-laoo" />
+  <info family="serif-laoo" family_name_style="short" use_preferred="t" />
   <info family="serif-laoo-new" family_name_style="very short" use_preferred="t" />
   <info family="serif-lgc" family_name_style="short" use_preferred="t" />
   <info family="serif-lgc-display" family_name_style="short" use_preferred="t" />

--- a/nototools/data/familyname_and_styles.txt
+++ b/nototools/data/familyname_and_styles.txt
@@ -11,21 +11,20 @@ NotoSansMonospace
 -- TRBH/CR/RI --
 NotoSerif
 NotoSerifDisplay
--- TRH --
+-- TRBH --
 NotoSansSymbols
 -- R --
 NotoSansSymbols2
 NotoMath
--- RB --
+-- TRBH --
 NotoSansThai
 NotoSansThaiUI
 -- TRBH/CR --
 NotoSansThaiNew
 NotoSansThaiNewUI
 NotoSerifThai
--- R --
-NotoSansHebrew
 -- TRBH/CR --
+NotoSansHebrew
 NotoSansHebrewNew
 NotoSerifHebrew  # no New
 NotoSansDevanagari
@@ -84,7 +83,7 @@ NotoSansEthiopic
 NotoSerifEthiopic
 -- RB --
 NotoNastaliqUrdu
--- TRH --
+-- TRBH --
 NotoSansOriya
 NotoSansOriyaUI
 NotoSerifOriya
@@ -211,7 +210,7 @@ Cousine
 -- R --
 NotoEmoji
 NotoColorEmoji
--- R --
+-- LB --
 NotoMono
 
 # CJK
@@ -234,10 +233,14 @@ noto-cjk/NotoSansTC
 NotoKufiArabic
 NotoNaskhArabic
 NotoNaskhArabicUI
+
+# legacy names since we haven't decided on naming yet
+-- TRBH --
 NotoSansCham
-NotoSansKhmr
-NotoSansKhmrUI
-NotoSerifKhmr
+-- TRBH/CR --
+NotoSansKhmer
+NotoSansKhmerUI
+NotoSerifKhmer
 NotoSansLao
 NotoSansLaoUI
 NotoSerifLao

--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -355,6 +355,7 @@ class TestSpec(object):
       unexpected
       format_12_has_bmp
       format_4_subset_of_12
+      unaliased
     required
     script_required except|only cp
     private_use except|only cp

--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -355,7 +355,7 @@ class TestSpec(object):
       unexpected
       format_12_has_bmp
       format_4_subset_of_12
-      unaliased
+      notaliased
     required
     script_required except|only cp
     private_use except|only cp

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -117,7 +117,8 @@ NotoFont = collections.namedtuple(
 
 
 WEIGHTS = {
-    'Thin': 250,
+    'Thin': 100,
+    'ExtraLight': 200,
     'Light': 300,
     'DemiLight': 350,
     'SemiLight': 350, # because currently some phase 3 fonts have this

--- a/nototools/noto_fonts.py
+++ b/nototools/noto_fonts.py
@@ -232,8 +232,9 @@ def get_noto_font(filepath, family_name='Arimo|Cousine|Tinos|Noto',
     hint_status = path.basename(filedir)
     if (hint_status not in ['hinted', 'unhinted']
         and 'noto-source' not in filedir):
-      print >> sys.stderr, (
-          'unknown hint status for %s, defaulting to unhinted') % filedir
+      # print >> sys.stderr, (
+      #    'unknown hint status for %s, defaulting to unhinted') % filedir
+      pass
     is_hinted = hint_status == 'hinted'
 
   manufacturer = (

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -197,8 +197,11 @@ def out_of_box_size(curve):
     # Bounding box of the bezier will contain that of the endpoints.
     # The out-of-box size for the entire curve will be maximum of the deviation
     # for the first curve and that of the remaining curve.
-    return max(ex1 - bx1, ey1 - by1, bx2 - ex2, by2 - ey2,
+    delta = max(ex1 - bx1, ey1 - by1, bx2 - ex2, by2 - ey2,
                out_of_box_size(remaining_curve))
+    # ignore very small deviations
+    return 0 if delta < 1 else delta
+
 
 def calc_bounds(piece):
     if len(piece) == 2:

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -748,7 +748,8 @@ def check_font(font_props, filename_error,
         cmap_table = font['cmap']
         cmaps = {}
         # Format 14 is variation sequences
-        expected_tables = [(4, 3, 1), (12, 3, 10), (14, 0, 5)]
+        expected_tables = [
+            (4, 3, 1), (12, 3, 10), (14, 0, 5), (4, 0, 3), (12, 0, 4)]
         if font_props.is_cjk:
             expected_tables.extend([
                 # Adobe says historically some programs used these to identify
@@ -758,10 +759,7 @@ def check_font(font_props, filename_error,
                 (6, 1, 2),  # Traditional Chinese
                 (6, 1, 3),  # Korean
                 (6, 1, 25), # Simplified Chinese
-                # Adobe says these just point at the windows versions, so there
-                # is no issue.
-                (4, 0, 3),    # Unicode, BMP only
-                (12, 0, 4)])  # Unicode, Includes Non-BMP
+                ])
         for table in cmap_table.tables:
             if (table.format,
                 table.platformID,
@@ -771,7 +769,15 @@ def check_font(font_props, filename_error,
                      "which it shouldn't have." % (
                          table.format, table.platformID, table.platEncID))
             elif table != (12, 0, 4):
-                cmaps[table.format] = table.cmap
+                if table.format in cmaps:
+                    # if we have both 4,3,1 and 4,0,3, they should be aliases
+                    # similarly if we have both 12,3,10 and 12,0,4
+                    if id(table.cmap) != id(cmaps[table.format]):
+                        warn("cmap/tables/notaliased", "cmap",
+                             "'cmap' has two format %d subtables that are not"
+                             " aliases" % table.format)
+                else:
+                  cmaps[table.format] = table.cmap
 
         if 4 not in cmaps:
             warn("cmap/tables/missing", "cmap",
@@ -781,11 +787,11 @@ def check_font(font_props, filename_error,
             cmap = cmaps[12]
             # if there is a format 12 table, it should have non-BMP characters
             if max(cmap.keys()) <= 0xFFFF:
-                warn("cmap/tables/format_12_has_bmp", "cmap",
-                     "'cmap' has a format 12 subtable but no "
-                     "non-BMP characters.")
+              warn("cmap/tables/format_12_has_bmp", "cmap",
+                   "'cmap' has a format 12 subtable but no "
+                   "non-BMP characters.")
 
-            # the format 4 table should be a subset of the format 12 one
+            # format 4 table should be a subset of the format 12 one
             if tests.check('cmap/tables/format_4_subset_of_12') and 4 in cmaps:
                 for char in cmaps[4]:
                     if char not in cmap:

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -428,10 +428,31 @@ def _manufacturer(noto_font):
   raise ValueError('unknown manufacturer "%s"' % noto_font.manufacturer)
 
 
+DESIGNER_STRINGS = {
+    'mti-chahine': 'Nadine Chahine - Monotype Design Team',
+    'mti-bosma': 'Jelle Bosma - Monotype Design Team',
+    'mti-hong': 'Danh Hong and the Monotype Design Team',
+    'mti': 'Monotype Design Team',
+}
+
+FAMILY_ID_TO_DESIGNER_KEY_P3 = {
+    'sans-arab': 'mti-chahine',
+    'sans-deva': 'mti-bosma',
+    'sans-khmr': 'mti-hong',
+    'serif-khmr': 'mti-hong',
+    'sans-sinh': 'mti-bosma',
+    'serif-sinh': 'mti-bosma',
+}
+
 def _designer(noto_font, phase):
   if noto_font.manufacturer == 'Adobe':
     return '-'
   if noto_font.manufacturer == 'Monotype':
+    if phase == 3:
+      family_id = noto_fonts.noto_font_to_family_id(noto_font)
+      designer_key = FAMILY_ID_TO_DESIGNER_KEY_P3.get(family_id)
+      if designer_key:
+        return DESIGNER_STRINGS[designer_key]
     if noto_font.family == 'Noto':
       if noto_font.style == 'Serif' and noto_font.script in [
           'Beng', 'Gujr', 'Knda', 'Mlym', 'Taml', 'Telu']:

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -376,8 +376,7 @@ def _postscript_name(preferred_family, preferred_subfamily, include_regular):
   # fix for names with punctuation
   punct_re = re.compile("[\s'-]")
   result = ''.join(punct_re.sub('', p) for p in wws_family)
-  tail = [n for n in wws_subfamily if
-          n not in wws_family and (include_regular or n != 'Regular')]
+  tail = [n for n in wws_subfamily if n not in wws_family]
   if tail:
     result += '-' + ''.join(tail)
 

--- a/nototools/notoconfig.py
+++ b/nototools/notoconfig.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +31,7 @@ import os
 from os import path
 
 # 'NOTOTOOLS_DIR' and 'DEFAULT_NOTOTOOLS' apparently don't work
-DEFAULT_ROOT = path.dirname(path.dirname(__file__))
+DEFAULT_ROOT = path.dirname(path.dirname(path.abspath(__file__)))
 
 values = {}
 
@@ -86,3 +87,12 @@ def get(key):
       return DEFAULT_ROOT
     raise Exception('.notoconfig has no entry for "%s"' % key)
   return values[key]
+
+
+if __name__ == '__main__':
+  keyset = set(values.keys())
+  keyset.add('noto_tools')
+  wid = max(len(k) for k in keyset)
+  fmt = '%%%ds: %%s' % wid
+  for k in sorted(keyset):
+    print fmt % (k, get(k))


### PR DESCRIPTION
A series of individually-small changes to make noto_lint more compatible with phase_3 fonts.  Also includes a few unrelated changes (notoconfig, quiet warnings). See individual commits for more info.

Should fix #344, #337, #336, #334, #333.