### PR TITLE
Fix 'python scripts' to locale python using env.

### DIFF
--- a/nototools/android_patches.py
+++ b/nototools/android_patches.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/autofix_for_release.py
+++ b/nototools/autofix_for_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/cldr_data.py
+++ b/nototools/cldr_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/cmap_block_coverage.py
+++ b/nototools/cmap_block_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/cmap_data.py
+++ b/nototools/cmap_data.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nototools/collect_cldr_punct.py
+++ b/nototools/collect_cldr_punct.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/compare_cmap_data.py
+++ b/nototools/compare_cmap_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/compare_fonts.py
+++ b/nototools/compare_fonts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/compare_summary.py
+++ b/nototools/compare_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/coverage.py
+++ b/nototools/coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/coverage_test.py
+++ b/nototools/coverage_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/create_image.py
+++ b/nototools/create_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8-unix -*-
 #
 # Copyright 2014 Google Inc. All rights reserved.

--- a/nototools/decompose_ttc.py
+++ b/nototools/decompose_ttc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/drop_hints.py
+++ b/nototools/drop_hints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/dump_otl.py
+++ b/nototools/dump_otl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/emoji_ordering.py
+++ b/nototools/emoji_ordering.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/extra_locale_data.py
+++ b/nototools/extra_locale_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
 # Copyright 2014 Google Inc. All rights reserved.

--- a/nototools/extract_ohchr_attributions.py
+++ b/nototools/extract_ohchr_attributions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/fix_khmer_and_lao_coverage.py
+++ b/nototools/fix_khmer_and_lao_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/fix_noto_cjk_thin.py
+++ b/nototools/fix_noto_cjk_thin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/font_caching.py
+++ b/nototools/font_caching.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/font_data.py
+++ b/nototools/font_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/gen_cplist.py
+++ b/nototools/gen_cplist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/generate_coverage_data.py
+++ b/nototools/generate_coverage_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/generate_dingbats_html.py
+++ b/nototools/generate_dingbats_html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/generate_emoji_name_data.py
+++ b/nototools/generate_emoji_name_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/generate_lang_font_table.py
+++ b/nototools/generate_lang_font_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/generate_sample_from_exemplar.py
+++ b/nototools/generate_sample_from_exemplar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nototools/generate_sample_text.py
+++ b/nototools/generate_sample_text.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/generate_sample_text_html.py
+++ b/nototools/generate_sample_text_html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/generate_samples.py
+++ b/nototools/generate_samples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/generate_website_2_data.py
+++ b/nototools/generate_website_2_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
 # Copyright 2015 Google Inc. All rights reserved.

--- a/nototools/generate_website_data.py
+++ b/nototools/generate_website_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
 # Copyright 2014 Google Inc. All rights reserved.

--- a/nototools/grab_adobe_download.py
+++ b/nototools/grab_adobe_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/grab_download.py
+++ b/nototools/grab_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/grab_mt_download.py
+++ b/nototools/grab_mt_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/lang_data.py
+++ b/nototools/lang_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
 # Copyright 2015 Google Inc. All rights reserved.

--- a/nototools/lint_cmap_reqs.py
+++ b/nototools/lint_cmap_reqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/merge_noto.py
+++ b/nototools/merge_noto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/missing_coverage.py
+++ b/nototools/missing_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/mti_cmap_data.py
+++ b/nototools/mti_cmap_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/noto_cmap_reqs.py
+++ b/nototools/noto_cmap_reqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/noto_data.py
+++ b/nototools/noto_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/noto_font_cmaps.py
+++ b/nototools/noto_font_cmaps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/noto_font_coverage.py
+++ b/nototools/noto_font_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/noto_lint.py
+++ b/nototools/noto_lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/noto_names.py
+++ b/nototools/noto_names.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nototools/notoconfig.py
+++ b/nototools/notoconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nototools/opentype_data.py
+++ b/nototools/opentype_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/render.py
+++ b/nototools/render.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/report_coverage_data.py
+++ b/nototools/report_coverage_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/sample_with_font.py
+++ b/nototools/sample_with_font.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/scale.py
+++ b/nototools/scale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/spreadsheet.py
+++ b/nototools/spreadsheet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/subset.py
+++ b/nototools/subset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/subset_font_cmap.py
+++ b/nototools/subset_font_cmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/nototools/subset_symbols.py
+++ b/nototools/subset_symbols.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/summary.py
+++ b/nototools/summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/swat_license.py
+++ b/nototools/swat_license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/test_vertical_extents.py
+++ b/nototools/test_vertical_extents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/ttc_utils.py
+++ b/nototools/ttc_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/unicode_data.py
+++ b/nototools/unicode_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/unicode_data_test.py
+++ b/nototools/unicode_data_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #

--- a/nototools/update_alpha.py
+++ b/nototools/update_alpha.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2015 Google Inc. All rights reserved.
 #

--- a/nototools/update_cldr.py
+++ b/nototools/update_cldr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
 # Copyright 2015 Google Inc. All rights reserved.

--- a/nototools/update_udhr_samples.py
+++ b/nototools/update_udhr_samples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
 # Copyright 2015 Google Inc. All rights reserved.


### PR DESCRIPTION
These scripts used to run python using /usr/bin/python, but this meant
that running them as executable scripts failed in environments like
virtualenv.

Also, a bunch of them were not actually executable despite having the
shebang line.  This makes them all executable.