### PR TITLE
Compressed ranges

### DIFF
--- a/nototools/generate_dingbats_html.py
+++ b/nototools/generate_dingbats_html.py
@@ -418,7 +418,11 @@ class CodeTableTarget(Target):
     if metrics != None:
       # the metrics apply to the rightmost font
       fontname = self.used_fonts[-1][1][0][0]
-      metrics_font = _get_font(fontname)
+      if fontname:
+        metrics_font = _get_font(fontname)
+      else:
+        metrics_font = None
+        print >> sys.stderr, 'no metrics font'
 
     lines = ['<h3 id="target_%d">%s</h3>' % (tindex, self.name)]
     char_line = _character_string_html(self.codelist, self.used_fonts[-1])
@@ -457,7 +461,7 @@ class CodeTableTarget(Target):
           line.append('<td>&nbsp;')
       name = _flagged_name(cp, flag_sets)
       if metrics != None:
-        cp_metrics = _get_cp_metrics(metrics_font, cp)
+        cp_metrics = _get_cp_metrics(metrics_font, cp) if metrics_font else None
         if cp_metrics:
           lsb, rsb, wid, adv, cy = cp_metrics
           if dump_metrics:

--- a/nototools/generate_dingbats_html.py
+++ b/nototools/generate_dingbats_html.py
@@ -130,7 +130,8 @@ class CodeList(object):
 
   @staticmethod
   def fromrangetext(cpranges):
-    return CodeList.fromset(tool_utils.parse_int_ranges(cpranges))
+    return CodeList.fromset(
+        tool_utils.parse_int_ranges(cpranges, allow_compressed=True))
 
   @staticmethod
   def fromrangefile(cprange_file):
@@ -143,17 +144,8 @@ class CodeList(object):
 
   @staticmethod
   def fromlisttext(cplist):
-    # we'll support ranges
-    if '-' not in cplist:
-      codes = [int(item, 16) for item in cplist.split()]
-    else:
-      codes = []
-      for item in cplist.split():
-        if '-' in item:
-          start, limit = (int(e, 16) for e in item.split('-'))
-          codes.extend(range(start, limit+1))
-        else:
-          codes.append(int(item, 16))
+    codes = tool_utils.parse_int_ranges(
+        cplist, allow_duplicates=True, return_set=False, allow_compressed=True)
     return CodeList.fromlist(codes)
 
   @staticmethod

--- a/nototools/tool_utils.py
+++ b/nototools/tool_utils.py
@@ -322,7 +322,15 @@ def parse_int_ranges(
   as a separator, and ranges following it or hyphen are interpreted as suffixes
   that replace the same number of characters at the end of the previous value.
   '-' generates the range of intervening characters as before, while '/' does
-  not.  Returns a set or a list depending on return_set."""
+  not.  Returns a set or a list depending on return_set.
+
+  For example, with compressed ranges the following:
+    1ee42/7/9/b/d-f 1ee51-2/4/7/9/b/d/f
+
+  expands to:
+    1ee42 1ee47 1ee49 1ee4b 1ee4d-1ee4f 1ee51-1ee52 1ee54 1ee57 1ee59 1ee5b
+    1ee5d 1ee5f
+  """
 
   base = 16 if is_hex else 10
   vals = []


### PR DESCRIPTION
Add a new syntax for the utility method that parses ranges from a text representation, and use it.

Also fixed a small issue in the tool used to generate character comparison review docs.