### PR TITLE
Add 'cros' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ TODAY=$(shell date "+%Y-%m-%d")
 TARBALLDIR=packages
 ZIPDIR=packages-zip
 ANDROIDDIR=packages/android
+CROSDIR=packages/cros
 HINTEDFONTDIR=../noto-fonts/hinted
 UNHINTEDFONTDIR=../noto-fonts/unhinted
 
 UNHINTEDFONTS=$(shell find $(UNHINTEDFONTDIR) -name "*.ttf")
 ANDROIDFONTS=$(UNHINTEDFONTS:$(UNHINTEDFONTDIR)/%=$(ANDROIDDIR)/%)
+
+HINTEDFONTS=$(shell find $(HINTEDFONTDIR) -name "*.ttf")
+CROSFONTS=$(HINTEDFONTS:$(HINTEDFONTDIR)/%=$(CROSDIR)/%)
 
 all: tarball zip
 
@@ -70,6 +74,12 @@ $(ANDROIDDIR)/%.ttf: $(UNHINTEDFONTDIR)/%.ttf
 	else \
 	    $(SUBSETTOOL) $< $@; \
 	fi
+
+cros: $(CROSFONTS)
+
+$(CROSDIR)/%.ttf: $(HINTEDFONTDIR)/%.ttf
+	@$(MKDIR) -p $(CROSDIR)
+	$(SUBSETTOOL) $< $@; \
 
 clean: cleantarball cleanzip
 

--- a/nototools/subset.py
+++ b/nototools/subset.py
@@ -56,6 +56,7 @@ def subset_font(source_file, target_file,
     opt.recalc_bounds = True
     opt.recalc_timestamp = True
     opt.canonical_order = True
+    opt.drop_tables = ['+TTFA']
 
     if options is not None:
         for name, value in options.iteritems():


### PR DESCRIPTION
This is used to copy hinted (auto or manually hinted) Noto fonts to
packages/cros directory while cycling them through subset.py to cut down the
font size a bit (dropping TTFA, changing post table version to 3, etc).

CrOS will take unhinted fonts from packages/android and hinted fonts
from packages/cros.