### PR TITLE
Add utility to sync noto font repos to release tags.

### DIFF
--- a/nototools/sync_repos.py
+++ b/nototools/sync_repos.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sync the noto repos to the given tags.
+
+This helps prepare for generating website data.  We have the option
+of requiring that the noto-fonts, noto-emoji, and noto-cjk repos are at
+tagged releases.  This tool lets you specify release names, ensures the
+release names are valid, and checks out those releases.  Main exits with
+error code 100 if there is a failure."""
+
+import argparse
+import sys
+
+from nototools import tool_utils
+
+_REPOS = 'fonts emoji cjk'.split()
+_REPO_PATHS = [tool_utils.resolve_path('[%s]' % r) for r in _REPOS]
+
+def noto_check_clean():
+  errors = []
+  for r, p in zip(_REPOS, _REPO_PATHS):
+    if not tool_utils.git_is_clean(p):
+      errors.append(r)
+
+  if errors:
+    print >> sys.stderr, '%s %s not clean' % (
+        ' '.join(errors), 'is' if len(errors) == 1 else 'are')
+    return False
+  return True
+
+
+def noto_checkout_master():
+  """Check out the noto repos at master.  Return True if ok, else log
+  error and return False."""
+
+  if not noto_check_clean():
+    return False
+
+  for p in _REPO_PATHS:
+    tool_utils.git_checkout(p, 'master')
+  return True
+
+
+def noto_checkout(
+    fonts_tag='latest', emoji_tag='latest', cjk_tag='latest', verbose=False):
+  """Check out the noto repos at the provided tags.  Return True if ok,
+  else log error and return False.  Default is 'latest' for the latest
+  tag."""
+
+  if not noto_check_clean():
+    return False
+
+  requested_tags = [fonts_tag, emoji_tag, cjk_tag]
+  failed_tags = []
+  resolved_tags = []
+  for r, p, t in zip(_REPOS, _REPO_PATHS, requested_tags):
+    found = False
+    tag_info = tool_utils.git_tags(p)
+    for _, tag, _ in tag_info:
+      if t == 'latest' or tag == t:
+        resolved_tags.append(tag)
+        found = True
+        break
+    if not found:
+      failed_tags.append('%s: %s' % (r, t))
+
+  if failed_tags:
+    print >> sys.stderr, 'failed to find:\n  %s' % '\n  '.join(failed_tags)
+    return False
+
+  for p, t in zip(_REPO_PATHS, resolved_tags):
+    tool_utils.git_checkout(p, t)
+
+  if verbose:
+    print 'checked out:\n  %s' % '\n  '.join(
+        '%s: %s' % (r, t) for r, t in zip(_REPOS, resolved_tags))
+
+  return True
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-f', '--fonts_tag', help='tag for noto fonts repo (default latest)',
+      metavar='tag', default='latest')
+  parser.add_argument(
+      '-e', '--emoji_tag', help='tag for noto emoji repo (default latest)',
+      metavar='tag', default='latest')
+  parser.add_argument(
+      '-c', '--cjk_tag', help='tag for noto cjk repo (default latest)',
+      metavar='tag', default='latest')
+  parser.add_argument(
+      '-m', '--master', help='use master branch for all repos',
+      action='store_true')
+  parser.add_argument(
+      '-v', '--verbose', help='report tags chosen on success',
+      action='store_true')
+
+  args = parser.parse_args()
+
+  if args.master:
+    result = noto_checkout_master()
+  else:
+    result = noto_checkout(
+        fonts_tag=args.fonts_tag, emoji_tag=args.emoji_tag,
+        cjk_tag=args.cjk_tag, verbose=args.verbose)
+  sys.exit(0 if result else 100)
+
+
+if __name__ == '__main__':
+  main()

--- a/nototools/tool_utils.py
+++ b/nototools/tool_utils.py
@@ -188,6 +188,15 @@ def zip_extract_with_timestamp(zippath, dstdir):
       os.utime(info.filename, (date_time, date_time))
 
 
+def git_checkout(repo, branch_or_tag, verbose=False):
+  """checkout the branch or tag"""
+  with temp_chdir(repo):
+    result = subprocess.check_output(
+        ['git', 'checkout', branch_or_tag], stderr=subprocess.STDOUT)
+    if verbose:
+      print '%s:\n%s\n-----' % (repo, result)
+
+
 def git_mv(repo, old, new):
   """Rename old to new in repo"""
   with temp_chdir(repo):


### PR DESCRIPTION
The tool to generate the get/noto data by default expects the font
repos to be at a tagged release.  It uses this information to generate
README documents for the download packages.  This enables development
teams that want to bundle our fonts to trace the packages back to
commits in the respective repos.

To simplify and automate this process its helpful to have a tool that
gets the repos to an acceptable state.  By default it checks out the
latest tagged release in each repo.  It is also possible to name a
release tag for any of the repos.  Finally, one can also check out
the master of each repo.