### PR TITLE
Add Pillow to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fonttools==3.9.1
 Pillow==4.0.0
 pyclipper==1.0.6
 ufoLib==2.0.0
+Pillow


### PR DESCRIPTION
In an environment I didn't have PIL installed and "pip install pil' didn't help.  Took some googling to find out that Pillow is the currently maintained fork of (dead) PIL.