### PR TITLE
Docker autohint

### DIFF
--- a/nototools/docker/devnoto/Dockerfile
+++ b/nototools/docker/devnoto/Dockerfile
@@ -2,7 +2,7 @@
 # Using this requires that you map the four core noto repos on the host
 # to /app/noto/nototools... etc.
 
-FROM notobase:latest
+FROM toolbase:latest
 COPY *.sh /tmp/
 RUN /tmp/notodevsetup.sh
 ENTRYPOINT ["/bin/bash"]

--- a/nototools/docker/toolbase/basesetup.sh
+++ b/nototools/docker/toolbase/basesetup.sh
@@ -4,7 +4,11 @@ set -e
 mkdir -p /app/pkgs
 
 # gtk2 for pango, ragel for autogen, gperf for fontconfig, python-lxml for fc build
-apt-get update && apt-get install -y python-gtk2 ragel gperf python-lxml
+# qt5-default for qtmake and to default to use qt5, for ttfautohint
+# (installing qt5-qmake and then export QT_SELECT=qt5 didn't work:
+#   qmake: could not find a Qt installation of 'qt5'
+# so perhaps qt5-qmake does not pull in qt5 dependencies automatically)
+apt-get update && apt-get install -y python-gtk2 ragel gperf python-lxml qt5-default
 
 # install a newer version of git
 GIT="git-2.12.2"
@@ -32,6 +36,20 @@ cd harfbuzz
 # git checkout 1.4.6
 ./autogen.sh
 make
+make install
+
+/sbin/ldconfig /usr/local/lib
+
+# get ttfautohint for font swatting
+# requires harfbuzz >= 1.3.0, so install after installing harfbuzz
+cd /app/pkgs
+AUTOHINT="1.7"
+wget https://sourceforge.net/projects/freetype/files/ttfautohint/${AUTOHINT}/ttfautohint-${AUTOHINT}.tar.gz -O - | tar -xz
+cd "ttfautohint-${AUTOHINT}"
+
+./configure
+make
+make check
 make install
 
 # behdad's cairo has the patch for color emoji
@@ -82,4 +100,3 @@ cd py2cairo
 # the image for debugging?
 
 echo "DONE"
-

--- a/nototools/docker/toolnoto/Dockerfile
+++ b/nototools/docker/toolnoto/Dockerfile
@@ -1,6 +1,6 @@
 # Build image for noto repos.
 
-FROM notobase:latest
+FROM toolbase:latest
 COPY *.sh /tmp/
 RUN /tmp/notosetup.sh
 RUN /tmp/initfccache.sh


### PR DESCRIPTION
Some updates to the docker images.  Building release fonts uses ttfautohint, but it wasn't in the image.