### PR TITLE
gpos_diff: Fixed parsing mark positions

### DIFF
--- a/nototools/gpos_diff.py
+++ b/nototools/gpos_diff.py
@@ -139,7 +139,7 @@ class GposDiffFinder:
         unmatched = {}
         mismatched = {}
         rx = re.compile('pos %s \[([\w\d\s@_.]+)\]\s+<anchor (-?\d+) (-?\d+)> '
-                        'mark (@[\w\d_.]+);' % mark_type)
+                        'mark (@?[\w\d_.]+);' % mark_type)
         self._parse_anchor_info(rx, '-', self.text_a, unmatched, mismatched)
         self._parse_anchor_info(rx, '+', self.text_b, unmatched, mismatched)
 

--- a/tests/gpos_diff_test.py
+++ b/tests/gpos_diff_test.py
@@ -38,6 +38,21 @@ class GposDiffFinderText(unittest.TestCase):
         for value_diff in values:
             self.assertIn('pos %s %s: %s vs %s' % value_diff, diffs)
 
+    def _expect_mark_positioning_diffs(self, source_a, source_b, values):
+        font_a = make_font('feature mark {\n%s\n} mark;' % source_a)
+        font_b = make_font('feature mark {\n%s\n} mark;' % source_b)
+        file_a = tempfile.NamedTemporaryFile()
+        file_b = tempfile.NamedTemporaryFile()
+        font_a.save(file_a.name)
+        font_b.save(file_b.name)
+        finder = GposDiffFinder(file_a.name, file_b.name, 0, 100)
+
+        diffs = finder.find_positioning_diffs()
+        self.assertIn('%d differences in mark-to-base positioning rule values' % len(values),
+                      diffs)
+        for value_diff in values:
+            self.assertIn('<%s %s> vs <%s %s>' % value_diff, diffs)
+
     def test_kern_simple(self):
         self._expect_kerning_diffs('''
                 pos a b -10;
@@ -69,6 +84,77 @@ class GposDiffFinderText(unittest.TestCase):
             ''',
             [('+', 'b', 'd', [-20])],
             [('a', 'd', [-10], [-20])])
+
+    def test_mark_positioning_diffs_simple(self):
+        """Find position differences for a single mark and single base glyph"""
+        self._expect_mark_positioning_diffs('''
+                markClass acute <anchor 150 -10> @TOP_MARKS;
+
+                position base a <anchor 250 450> mark @TOP_MARKS;
+            ''','''
+                markClass acute <anchor 150 -10> @TOP_MARKS;
+
+                position base a <anchor 0 0> mark @TOP_MARKS;
+            ''',
+            [(250, 450, 0, 0)])
+
+
+    def test_mark_positioning_diffs_on_groups(self):
+        """Find position differences for groups"""
+        self._expect_mark_positioning_diffs('''
+                markClass [acute grave] <anchor 150 -10> @TOP_MARKS;
+
+                position base [a e o u] <anchor 250 450> mark @TOP_MARKS;
+            ''','''
+                markClass [acute grave] <anchor 150 -50> @TOP_MARKS;
+
+                position base [a e o u] <anchor 0 0> mark @TOP_MARKS;
+            ''',
+            [(250, 450, 0, 0),
+             (250, 450, 0, 0),
+             (250, 450, 0, 0),
+             (250, 450, 0, 0)])
+
+    def test_mark_positioning_diffs_on_classes(self):
+        """Find position differences on classes"""
+        self._expect_mark_positioning_diffs('''
+                @top = [acute grave];
+                @base_glyphs = [a e o u];
+
+                markClass @top <anchor 150 -10> @TOP_MARKS;
+
+                position base @base_glyphs <anchor 250 450> mark @TOP_MARKS;
+            ''','''
+                @top = [acute grave];
+                @base_glyphs = [a e o u];
+
+                markClass @top <anchor 150 -50> @TOP_MARKS;
+
+                position base @base_glyphs <anchor 0 0> mark @TOP_MARKS;
+            ''',
+            [(250, 450, 0, 0),
+             (250, 450, 0, 0),
+             (250, 450, 0, 0),
+             (250, 450, 0, 0)])
+
+    def test_mark_positioning_diffs_mark_on_mark(self):
+        """Find positions differences on mark to mark positions"""
+        self._expect_mark_positioning_diffs('''
+            @top = [acute grave];
+
+            markClass @top <anchor 150 -10> @TOP_MARKS;
+
+            position base @top <anchor 250 450> mark @TOP_MARKS;
+        ''','''
+            @top = [acute grave];
+
+            markClass @top <anchor 150 -50> @TOP_MARKS;
+
+            position base @top <anchor 0 0> mark @TOP_MARKS;
+        ''',
+        [(250, 450, 0, 0),
+         (250, 450, 0, 0)])
+
 
 
 if __name__ == '__main__':

--- a/tests/gpos_diff_test.py
+++ b/tests/gpos_diff_test.py
@@ -38,7 +38,7 @@ class GposDiffFinderText(unittest.TestCase):
         for value_diff in values:
             self.assertIn('pos %s %s: %s vs %s' % value_diff, diffs)
 
-    def test_simple(self):
+    def test_kern_simple(self):
         self._expect_kerning_diffs('''
                 pos a b -10;
                 pos a c -20;
@@ -49,7 +49,7 @@ class GposDiffFinderText(unittest.TestCase):
             [('-', 'a', 'c', [-20]), ('+', 'a', 'd', [-40])],
             [('a', 'b', [-10], [-30])])
 
-    def test_multiple_rules(self):
+    def test_kern_multiple_rules(self):
         self._expect_kerning_diffs('''
                 @a_b = [a b];
                 pos a d -10;
@@ -60,7 +60,7 @@ class GposDiffFinderText(unittest.TestCase):
             [('-', 'b', 'd', [-20])],
             [('a', 'd', [-10, -20], [-30])])
 
-    def test_single_vs_class(self):
+    def test_kern_single_vs_class(self):
         self._expect_kerning_diffs('''
                 pos a d -10;
             ''', '''


### PR DESCRIPTION
In the previous implementation, a mark positioning rule for a single glyph wouldn't get parsed.

By adding ? to the regular expression in the method find_positioning_diffs, it can now parse both single glyphs, classes and groups.

The new test, *test_mark_positioning_diffs_simple* will test this functionality. I've added extra tests to ensure positioning diffs are being reported correctly as well.

I have renamed the existing kerning tests to avoid confusion.

If this pr gets approved, I will cleanup the helper methods in the tests _expect_kerning_diffs and _expect_mark_positioning_diffs, there's a lot of overlap. 