### PR TITLE
[hb_input] get unicode from ordinal past 10000 on narrow Python build

### DIFF
--- a/nototools/hb_input.py
+++ b/nototools/hb_input.py
@@ -94,7 +94,12 @@ class HbInputGenerator(object):
 
         # see if this glyph has a simple unicode mapping
         if name in self.reverse_cmap:
-            text = unichr(self.reverse_cmap[name])
+            try:
+                text = unichr(self.reverse_cmap[name])
+            except ValueError:
+                ordinal = self.reverse_cmap[name]
+                uni_esc = "\\U%08x" % ordinal
+                text = uni_esc.decode('unicode-escape')
             inputs.append(((), text))
 
         # check the substitution features

--- a/nototools/hb_input.py
+++ b/nototools/hb_input.py
@@ -16,6 +16,7 @@
 from __future__ import division, print_function
 
 from fontTools.ttLib import TTFont
+from fontTools.misc.py23 import unichr
 from nototools import summary
 
 
@@ -94,12 +95,7 @@ class HbInputGenerator(object):
 
         # see if this glyph has a simple unicode mapping
         if name in self.reverse_cmap:
-            try:
-                text = unichr(self.reverse_cmap[name])
-            except ValueError:
-                ordinal = self.reverse_cmap[name]
-                uni_esc = "\\U%08x" % ordinal
-                text = uni_esc.decode('unicode-escape')
+            text = unichr(self.reverse_cmap[name])
             inputs.append(((), text))
 
         # check the substitution features


### PR DESCRIPTION
When trying to run hbinput on the [Roboto sources](https://github.com/google/roboto/tree/master/src/hinted), I get the following traceback

```
Traceback (most recent call last):
  File "_hbtest.py", line 8, in <module>
    print seq.all_inputs()
  File "/Users/marc/Documents/nototools/nototools/hb_input.py", line 60, in all_inputs
    cur_input = self.input_from_name(name, pad=is_zero_width)
  File "/Users/marc/Documents/nototools/nototools/hb_input.py", line 97, in input_from_name
    text = unichr(self.reverse_cmap[name])
ValueError: unichr() arg not in range(0x10000) (narrow Python build)

```

If you're running a narrow Python build, the function unichr will only return unicode chars from ordinals up to 10000. Roboto has two glyphs which are outside this range, [uni1F16A](http://www.fileformat.info/info/unicode/char/1f16a/index.htm) and [uni1F16B](http://www.fileformat.info/info/unicode/char/1f16b/index.htm).

We can address this issue by converting the ordinal into a unicode esc string, its then stored as a UT-16 surrogate pair on narrow build, which can then be reencoded back to utf-8.

This is not my solution but it works nicely. Found it here, https://stackoverflow.com/questions/7105874/valueerror-unichr-arg-not-in-range0x10000-narrow-python-build/7107319